### PR TITLE
Prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-23
+
 ### Added
 
 - `idempotency.jdbc.join-transaction` (boolean, default `false`). When enabled, the aspect runs the
@@ -18,7 +20,7 @@ All notable changes to this project are documented in this file.
 - The JDBC store's Gradle module description and the `idempotency.store=jdbc` configuration-metadata
   hint no longer claim unconditional exactly-once; both now name the property that provides it.
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-08-02
 
 First public release.
 
@@ -44,7 +46,7 @@ First public release.
 
 - The JDBC store is at-least-once via `@Idempotent` alone; genuine exactly-once requires the
   application to call `IdempotencyStore.complete()` from inside a transaction it already holds
-  open. Transaction-joining the completion write automatically is targeted for 0.2.
+  open. (Resolved in 0.2.0 by `idempotency.jdbc.join-transaction`.)
 - `on-conflict=WAIT` under a large concurrent duplicate burst can measurably degrade whole-application
   thread-pool responsiveness, not just the affected endpoint.
 - `on-store-failure=proceed`'s worst-case request latency depends entirely on the consumer's own

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ replayed** — not a re-execution, not an error.
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.1.0") // use the latest published version
-    implementation("io.github.benhendayoussef:idempotency-store-redis:0.1.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.2.0") // use the latest published version
+    implementation("io.github.benhendayoussef:idempotency-store-redis:0.2.0")
 }
 ```
 
@@ -51,8 +51,8 @@ The JDBC store needs more setup than swapping one dependency — all of the foll
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.1.0") // use the latest published version
-    implementation("io.github.benhendayoussef:idempotency-store-jdbc:0.1.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.2.0") // use the latest published version
+    implementation("io.github.benhendayoussef:idempotency-store-jdbc:0.2.0")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     runtimeOnly("org.postgresql:postgresql")
 }
@@ -242,7 +242,7 @@ Nobody else publishes this table. If you only remember one thing from this READM
 "idempotent" and "exactly-once" are not the same claim, and getting the latter from the JDBC store
 takes more than swapping in the dependency.
 
-## Limitations (v0.1)
+## Limitations
 
 Being loud about these is what makes a library trustworthy:
 
@@ -301,8 +301,6 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
-- [`docs/explained/`](docs/explained/00-overview.md) — a class-by-class walkthrough of the
-  entire codebase.
 
 ## Extending
 
@@ -325,6 +323,7 @@ app's own `ObjectMapper`).
 
 | Starter version | Spring Boot | Java |
 |---|---|---|
+| 0.2.x | 4.1.x (Spring Framework 7) | 17+ |
 | 0.1.x | 4.1.x (Spring Framework 7) | 17+ |
 
 ## Roadmap


### PR DESCRIPTION
CHANGELOG: promote the accumulated Unreleased section to 0.2.0 and give 0.1.0 its real release date - it was still marked Unreleased despite having been on Maven Central since 2026-08-02. Its "targeted for 0.2" limitation note now points at the release that resolved it.

README: add the 0.2.x compatibility row, and move the install snippets to 0.2.0 so a reader copying them gets the version this documentation describes. The limitations heading was pinned to v0.1 but the list is not version specific.

Also removes a dead link to docs/explained/, which no longer exists in the repository - the directory went away during the history cleanup and the link was never updated, so the published README pointed at a 404.