### PR TITLE
Support Spring Boot 3 alongside Spring Boot 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
 
 jobs:
   build:
+    # The whole suite runs against both supported Spring Boot generations from one source tree.
+    # Nothing in the library is version-specific - the matrix exists to keep it that way, since the
+    # ways these two diverge (autoconfiguration package renames, which ObjectMapper wins
+    # @ConditionalOnMissingBean) all fail silently rather than at compile time.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The lower bound, and what the published artifacts are compiled against.
+          - spring-boot: '3.5.6'
+            label: 'Spring Boot 3.5'
+          - spring-boot: '4.1.0'
+            label: 'Spring Boot 4.1'
+
+    name: ${{ matrix.label }}
+
     # Docker is preinstalled on GitHub-hosted ubuntu-latest runners, required for the
     # Testcontainers-backed idempotency-store-redis/idempotency-store-jdbc test suites.
     runs-on: ubuntu-latest
@@ -23,7 +39,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
-        run: ./gradlew clean build
+        run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} clean build
 
       # Virtual threads don't exist on the project's pinned Java 17 toolchain; this task runs the
       # same test sources on a separately-provisioned JDK 21+ launcher without changing what the
@@ -35,11 +51,11 @@ jobs:
           java-version: '21'
 
       - name: Virtual threads check
-        run: ./gradlew :idempotency-spring-boot-starter:testVirtualThreads
+        run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} :idempotency-spring-boot-starter:testVirtualThreads
 
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-boot-${{ matrix.spring-boot }}
           path: '**/build/reports/tests/'

--- a/README.md
+++ b/README.md
@@ -326,8 +326,13 @@ app's own `ObjectMapper`).
 
 | Starter version | Spring Boot | Java |
 |---|---|---|
+| 0.3.x | **3.5.x and 4.1.x** | 17+ |
 | 0.2.x | 4.1.x (Spring Framework 7) | 17+ |
 | 0.1.x | 4.1.x (Spring Framework 7) | 17+ |
+
+From 0.3.0 there is **one artifact for both Spring Boot generations** - no `-boot3` classifier and no
+separate version line. Every Spring API the library uses exists in both, so it is compiled against the
+lower bound and the full suite runs against both in CI on every push.
 
 ## Roadmap
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,19 @@ subprojects {
 
     repositories { mavenCentral() }
 
+    // The Boot generation under test is a build parameter so CI can run the whole suite against
+    // both Spring Boot 3.x and 4.x from one source tree. The version catalog supplies the default;
+    // -PspringBootVersion=3.5.6 overrides it. Published artifacts are compiled against the lower
+    // bound (see the compatibility matrix in the README), which is what makes one artifact work on
+    // both - every Spring API this library touches exists in both generations.
+    val springBootVersion = providers.gradleProperty("springBootVersion")
+        .getOrElse(rootProject.libs.versions.springBoot.get())
+    val springBootBom = "org.springframework.boot:spring-boot-dependencies:$springBootVersion"
+
     dependencies {
-        add("implementation", platform(rootProject.libs.spring.boot.dependencies))
-        add("annotationProcessor", platform(rootProject.libs.spring.boot.dependencies))
-        add("testImplementation", platform(rootProject.libs.spring.boot.dependencies))
+        add("implementation", platform(springBootBom))
+        add("annotationProcessor", platform(springBootBom))
+        add("testImplementation", platform(springBootBom))
         add("testImplementation", platform(rootProject.libs.testcontainers.bom))
         add("testImplementation", rootProject.libs.assertj.core)
         add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
     testImplementation(project(":idempotency-store-jdbc"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
-    // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its
-    // own module; spring-boot-starter-test does not pull it in transitively.
-    testImplementation("org.springframework.boot:spring-boot-webmvc-test")
+    // No spring-boot-webmvc-test here on purpose: that module is Boot 4 only, and depending on it
+    // is what used to pin this suite to a single Boot generation. MockMvcTestConfiguration builds
+    // MockMvc from spring-test instead, which is identical on Boot 3 and 4.
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-data-redis")
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc")

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -32,6 +32,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -56,9 +57,29 @@ import org.springframework.transaction.PlatformTransactionManager;
 // Referenced by name, not by class literal: both are optional (compileOnly) and may not be on
 // the classpath at all, unlike a hard `after = {Foo.class}` this doesn't fail attribute
 // introspection when the referenced autoconfiguration is absent.
+//
+// Both Boot generations are listed because Boot 4 moved these autoconfigurations into per-module
+// packages. Naming only one generation would not fail on the other - it would silently match
+// nothing, so the store beans could be evaluated before the DataSource or StringRedisTemplate they
+// depend on exists. A name matching nothing is simply ignored, which is what makes listing all four
+// safe on both. See IdempotencyAutoConfigurationOrderingTest.
 @AutoConfiguration(afterName = {
+        // Spring Boot 4.x
         "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration",
-        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+        // Spring Boot 3.x
+        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration",
+        "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+        // Jackson, both generations. Not about bean availability like the four above - this one
+        // decides who owns the application-wide ObjectMapper. idempotencyPayloadObjectMapper is a
+        // bean of type ObjectMapper, and Spring Boot declares its own @Primary one behind
+        // @ConditionalOnMissingBean. Register ours first and Boot backs off entirely, so the
+        // starter-internal mapper silently becomes the mapper the application serializes every HTTP
+        // response with - and any IdempotencyObjectMapperCustomizer leaks into the app's own wire
+        // format. Ordering after Jackson means Boot's @Primary mapper always wins for the
+        // application and ours stays private to replay storage.
+        "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
+        "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration"
 })
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.SERVLET)
@@ -142,7 +163,8 @@ public class IdempotencyAutoConfiguration {
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,
-            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics,
+            @Qualifier("idempotencyPayloadObjectMapper") ObjectMapper idempotencyPayloadObjectMapper,
+            IdempotencyMetrics metrics,
             ObjectProvider<TransactionRunner> transactionRunner) {
         TransactionRunner runner = transactionRunner.getIfAvailable();
         if (runner == null && props.getJdbc().isJoinTransaction()) {
@@ -176,7 +198,8 @@ public class IdempotencyAutoConfiguration {
         @ConditionalOnMissingBean(IdempotencyStore.class)
         @ConditionalOnBean(StringRedisTemplate.class)
         IdempotencyStore redisIdempotencyStore(StringRedisTemplate redisTemplate,
-                ObjectMapper idempotencyPayloadObjectMapper, IdempotencyProperties props) {
+                @Qualifier("idempotencyPayloadObjectMapper") ObjectMapper idempotencyPayloadObjectMapper,
+                IdempotencyProperties props) {
             return new RedisIdempotencyStore(redisTemplate, idempotencyPayloadObjectMapper,
                     props.getRedis().getKeyPrefix());
         }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationOrderingTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationOrderingTest.java
@@ -1,0 +1,78 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+
+/**
+ * Guards the {@code afterName} ordering that makes the starter work on both Spring Boot generations.
+ *
+ * <p>{@link IdempotencyAutoConfiguration} must be applied <em>after</em> the autoconfigurations that
+ * supply a {@code DataSource} or a {@code StringRedisTemplate}, or its {@code @ConditionalOnBean}
+ * store beans can be evaluated before those beans exist and silently back off - leaving an
+ * application with no store and a startup failure that points at the wrong thing.
+ *
+ * <p>Boot 4 moved both of those autoconfigurations into per-module packages, so the names differ
+ * between generations. The failure mode this test exists for is nasty precisely because it is
+ * <strong>silent</strong>: an {@code afterName} entry that matches no class is simply ignored, so
+ * naming only one generation still starts up, still passes most tests, and only misbehaves on the
+ * other generation under the specific bean-timing that ordering exists to prevent. Nothing about
+ * that failure is visible at compile time, which is why it is asserted here by name.
+ */
+class IdempotencyAutoConfigurationOrderingTest {
+
+    private static final String BOOT4_REDIS =
+            "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration";
+    private static final String BOOT4_JDBC =
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration";
+    private static final String BOOT3_REDIS =
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration";
+    private static final String BOOT3_JDBC =
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration";
+
+    private List<String> afterNames() {
+        AutoConfiguration ann = AnnotatedElementUtils.findMergedAnnotation(
+                IdempotencyAutoConfiguration.class, AutoConfiguration.class);
+        assertThat(ann).as("IdempotencyAutoConfiguration must be an @AutoConfiguration").isNotNull();
+        return Arrays.asList(ann.afterName());
+    }
+
+    @Test
+    void ordersItselfAfterBothGenerationsOfTheStoreAutoConfigurations() {
+        assertThat(afterNames())
+                .as("dropping any of these silently disables ordering on that Boot generation")
+                .contains(BOOT4_REDIS, BOOT4_JDBC, BOOT3_REDIS, BOOT3_JDBC);
+    }
+
+    /**
+     * Whichever generation is actually on the test classpath, at least one Redis and one JDBC name
+     * must resolve to a real class. This is what would catch a typo or an upstream rename - the
+     * assertion above only proves the strings are present, not that they mean anything.
+     */
+    @Test
+    void atLeastOneNamedAutoConfigurationResolvesOnTheActiveClasspath() {
+        assertThat(resolvable(BOOT4_REDIS, BOOT3_REDIS))
+                .as("no Redis autoconfiguration name matched a real class - the afterName entries are "
+                        + "either misspelled or the upstream class moved again")
+                .isTrue();
+        assertThat(resolvable(BOOT4_JDBC, BOOT3_JDBC))
+                .as("no DataSource autoconfiguration name matched a real class")
+                .isTrue();
+    }
+
+    private static boolean resolvable(String... candidates) {
+        for (String fqn : candidates) {
+            try {
+                Class.forName(fqn);
+                return true;
+            } catch (ClassNotFoundException ignored) {
+                // Wrong generation for this classpath - try the next.
+            }
+        }
+        return false;
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -22,7 +22,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -178,7 +177,7 @@ class IdempotencyAutoConfigurationTest {
         // StringRedisTemplate as long as a RedisConnectionFactory exists - verified here against
         // the real autoconfiguration, not a hand-rolled stand-in.
         new WebApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(DataRedisAutoConfiguration.class,
+                .withConfiguration(AutoConfigurations.of(springRedisAutoConfiguration(),
                         IdempotencyAutoConfiguration.class, IdempotencyStoreFallbackAutoConfiguration.class))
                 .withUserConfiguration(RedisConnectionFactoryOnlyConfiguration.class, CustomNonStringRedisTemplateConfiguration.class)
                 .run(ctx -> {
@@ -393,5 +392,25 @@ class IdempotencyAutoConfigurationTest {
             template.afterPropertiesSet();
             return template;
         }
+    }
+
+    /**
+     * Boot 4 renamed and repackaged Redis autoconfiguration ({@code DataRedisAutoConfiguration}) from
+     * the Boot 3 {@code RedisAutoConfiguration}. This test needs the real one - the whole point is to
+     * verify against Spring Boot&#39;s own autoconfiguration rather than a hand-rolled stand-in - so it is
+     * resolved by name and whichever generation is on the classpath wins.
+     */
+    private static Class<?> springRedisAutoConfiguration() {
+        for (String fqn : List.of(
+                "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration",
+                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration")) {
+            try {
+                return Class.forName(fqn);
+            } catch (ClassNotFoundException ignored) {
+                // Wrong generation - try the next.
+            }
+        }
+        throw new IllegalStateException(
+                "Neither the Boot 3 nor the Boot 4 Redis autoconfiguration is on the test classpath");
     }
 }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/AbstractIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/AbstractIdempotencyBehaviorTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -55,7 +55,7 @@ import org.springframework.web.servlet.HandlerMapping;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
         classes = AbstractIdempotencyBehaviorTest.TestApp.class)
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 abstract class AbstractIdempotencyBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CustomJacksonModuleTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CustomJacksonModuleTest.java
@@ -23,8 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
                 CustomJacksonModuleTest.PointModuleConfiguration.class},
         properties = {"idempotency.store=memory", "idempotency.scope=global",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class CustomJacksonModuleTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/InMemoryStoreOverheadTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/InMemoryStoreOverheadTest.java
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
         classes = InMemoryStoreOverheadTest.TestApp.class,
         properties = {"idempotency.store=memory", "idempotency.scope=global",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class InMemoryStoreOverheadTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/JdbcStoreUnavailableBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/JdbcStoreUnavailableBehaviorTest.java
@@ -14,8 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
                 // SpringSecurityOrderingTest) - see TestAutoconfigExcludes.
                 TestAutoconfigExcludes.EXCLUDE_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class JdbcStoreUnavailableBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MockMvcTestConfiguration.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MockMvcTestConfiguration.java
@@ -1,0 +1,42 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import jakarta.servlet.Filter;
+import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Supplies the {@link MockMvc} bean that {@code @AutoConfigureMockMvc} used to provide.
+ *
+ * <p>Boot 4 moved that annotation into its own {@code spring-boot-webmvc-test} module, which does
+ * not exist in Boot 3 - it was the <strong>single</strong> thing preventing this test suite from
+ * compiling against both generations. Building {@code MockMvc} by hand costs a few lines and
+ * removes the only version-specific dependency in the project, so the same sources run on Boot 3.x
+ * and 4.x with no source sets, no reflection, and no duplicated tests.
+ *
+ * <p>Everything here comes from {@code spring-test} and {@code jakarta.servlet}, both of which are
+ * identical across the two generations.
+ */
+@Configuration(proxyBeanMethods = false)
+class MockMvcTestConfiguration {
+
+    @Bean
+    MockMvc mockMvc(WebApplicationContext context, ObjectProvider<Filter> filters) {
+        var builder = MockMvcBuilders.webAppContextSetup(context);
+
+        // Registering the context's servlet filters is not incidental: SpringSecurityOrderingTest
+        // asserts that an unauthenticated request is rejected with 401 by the security filter chain
+        // *before* it ever reaches the dispatcher and the aspect. Without the filters attached that
+        // test would pass for the wrong reason - the request would sail through to the handler.
+        // orderedStream() honours @Order/Ordered, so the chain keeps its real relative ordering.
+        List<Filter> registered = filters.orderedStream().toList();
+        if (!registered.isEmpty()) {
+            builder.addFilters(registered.toArray(new Filter[0]));
+        }
+        return builder.build();
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/RedisStoreUnavailableBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/RedisStoreUnavailableBehaviorTest.java
@@ -14,8 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
                 // other tests in this module) - see TestAutoconfigExcludes.
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class RedisStoreUnavailableBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SlowStoreBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SlowStoreBehaviorTest.java
@@ -16,8 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
                 "spring.data.redis.connect-timeout=1s",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class SlowStoreBehaviorTest {
 
     private static ServerSocket wedgedServer;

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SpringSecurityOrderingTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SpringSecurityOrderingTest.java
@@ -12,9 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -37,8 +37,9 @@ import org.springframework.web.bind.annotation.RestController;
         classes = {SpringSecurityOrderingTest.TestApp.class, SpringSecurityOrderingTest.SecurityConfig.class,
                 SpringSecurityOrderingTest.SecuredController.class},
         properties = {"idempotency.store=memory",
-                "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
-@AutoConfigureMockMvc
+                // Shared constant so this names both Boot generations - see TestAutoconfigExcludes.
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE})
+@Import(MockMvcTestConfiguration.class)
 class SpringSecurityOrderingTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
@@ -11,14 +11,23 @@ package io.github.benhendayoussef.idempotency.behavior;
  */
 final class TestAutoconfigExcludes {
 
+    // Both generations are named. Boot ignores an exclude entry whose class is not on the
+    // classpath, so the pair is safe on either - and naming only one would silently stop
+    // excluding anything on the other, letting Boot supply the very DataSource these tests
+    // exist to run without.
     private static final String NO_DATASOURCE =
-            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration";
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration";
     // Excludes only the autoconfiguration that installs Boot's default restrictive filter chain -
     // not the base SecurityAutoConfiguration, which also registers the SecurityProperties bean
     // other core Boot autoconfigurations (error handling) depend on regardless of whether a
     // security filter chain is wanted.
     private static final String NO_SECURITY =
-            "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration";
+            "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration";
+
+    /** For tests that configure no DataSource of their own but do want default security. */
+    static final String EXCLUDE_DATASOURCE = "spring.autoconfigure.exclude=" + NO_DATASOURCE;
 
     /** For JDBC-store tests: they need a real DataSource, just not Boot's default security. */
     static final String EXCLUDE_SECURITY = "spring.autoconfigure.exclude=" + NO_SECURITY;


### PR DESCRIPTION
First of the six items scoped for 0.3.0.

## What pinned us to Boot 4 was almost nothing

I expected scattered Framework 7 APIs. There are none. **All four modules' main sources compile against Spring Boot 3.5.6 unchanged** — every one of the 47 distinct `org.springframework.*` imports exists identically in both generations. `ProblemDetail`, `ErrorResponse`, `AbstractFailureAnalyzer`, the `@ConditionalOn*` family, `spring.factories`, `jakarta.*`, Java 17. All Boot 3 era or earlier.

That's partly design rather than luck: the starter references optional autoconfigurations *by name* rather than by class literal, so it never binds to a version-specific type at compile time.

So this PR is mostly test infrastructure, plus a real bug the work uncovered.

## The production change

Boot 4 moved the Redis and DataSource autoconfigurations into per-module packages, so `afterName` now lists **both** generations.

Naming only one generation doesn't fail on the other — it silently matches nothing and stops ordering altogether, which is the worst of the three possible outcomes: the store beans can then be evaluated before the `DataSource` they need exists. `IdempotencyAutoConfigurationOrderingTest` pins all four names so a rename can't quietly undo it.

The same by-name trick covers `spring.autoconfigure.exclude` in tests — Boot ignores an exclude naming an absent class, so listing both is safe on either.

## The one hard blocker

`@AutoConfigureMockMvc` moved into `spring-boot-webmvc-test`, which has no Boot 3 equivalent — it was the *single* thing preventing the suite from compiling on both. `MockMvcTestConfiguration` builds `MockMvc` from `spring-test` instead, identical across generations, and the Boot-4-only dependency is gone.

It registers the context's servlet filters deliberately: `SpringSecurityOrderingTest` asserts a 401 from the security chain *before* the request reaches the aspect. Without the filters attached, that test would pass for the wrong reason.

## A real defect this surfaced

`idempotencyPayloadObjectMapper` is a bean of type `ObjectMapper`, and Spring Boot declares its own `@Primary` one behind `@ConditionalOnMissingBean`. Registering ours first made **Boot back off entirely** — so the starter's internal payload mapper silently became the mapper the application serialized *every HTTP response* with, and any `IdempotencyObjectMapperCustomizer` leaked into the application's own wire format.

`CustomJacksonModuleTest` caught it on Boot 3: the response came back as `"3,4"` (the test's custom serializer) instead of `{"x":3,"y":4}`.

Fixed by ordering after Jackson's autoconfiguration on both generations, so Boot's `@Primary` mapper always wins for the application. The two injection points now bind by `@Qualifier`, because once Boot's mapper exists `@Primary` beats parameter-name matching — without that the aspect would silently get the *application's* mapper and lose every customizer.

This bug exists in 0.2.0 and earlier. It just wasn't reachable until the ordering was examined.

## Verification

The Boot generation is now a build parameter, and CI runs the whole suite against both:

```
./gradlew -PspringBootVersion=3.5.6 clean build
./gradlew clean build                              # 4.1.0, the catalog default
```

Both pass locally. The matrix on this PR is the real check.

**One local-environment caveat, not a code issue:** on Windows with Docker Desktop, Boot 3's BOM pins Testcontainers 1.21.3, which can't reach the `dockerDesktopLinuxEngine` named pipe (Boot 4 pins 2.0.5, which can). I verified the full Boot 3 suite green by temporarily forcing Testcontainers 2.0.5. On Linux CI both versions use the unix socket, so the matrix here exercises the real thing.

## Not in this PR

Micrometer metrics, MySQL store, Caffeine store, WebFlux, and `mode: filter` — the other five 0.3.0 items.
