### PR TITLE
Publish idempotency metrics to Micrometer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Micrometer metrics, wired automatically when the application has a `MeterRegistry`. Every outcome
+  lands on one counter, `idempotency.requests`, tagged by `outcome` - so a replay rate is a single
+  ratio rather than a hard-coded list of metric names. `idempotency.metrics.enabled=false` opts out;
+  a user-supplied `IdempotencyMetrics` bean still wins.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ a silent execution of the wrong payload.
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
 | `idempotency.jdbc.sweeper-interval` | `15m` | |
 | `idempotency.jdbc.join-transaction` | `false` | Run the handler and the completion write in one shared transaction — exactly-once instead of at-least-once. Costs: non-`@Transactional` handlers get pulled into a transaction, and a handler's own `@Transactional(timeout)` stops applying. [Read the caveats first](#opt-in-exactly-once-via-transaction-joining) |
+| `idempotency.metrics.enabled` | `true` | Publish counters to Micrometer when a `MeterRegistry` exists. No effect without one |
 
 ## Store comparison
 
@@ -304,6 +305,39 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## Metrics
+
+If your application already has a Micrometer `MeterRegistry` (adding `spring-boot-starter-actuator`
+is enough), the starter publishes counters automatically. There is nothing to configure.
+
+Everything lands on **one** counter, `idempotency.requests`, separated by an `outcome` tag:
+
+| `outcome` | Meaning |
+|---|---|
+| `executed` | Handler ran; the response was stored for replay |
+| `replayed` | A duplicate was answered from the store without executing |
+| `replayed_after_wait` | A `WAIT`-policy duplicate blocked, then replayed the first call’s response |
+| `released` | The key was released so a retry can re-execute (5xx, or a timeout) |
+| `conflict` | A duplicate arrived while the first was in flight and got a 409 |
+| `wait_timeout` | A `WAIT`-policy duplicate gave up waiting |
+| `fingerprint_mismatch` | Same key, different request body - the 422 case |
+| `missing_key` | No idempotency key on the request |
+| `store_failure` | The store was unreachable |
+| `principal_missing` | A `user`/`tenant`-scoped request had no resolvable principal |
+
+One name with a tag rather than ten names is deliberate: it lets you write a replay rate as a single
+ratio, and an outcome added in a later version shows up in your existing queries instead of being
+invisible until you update them.
+
+```promql
+# Replay rate: the share of idempotent traffic served without re-executing
+sum(rate(idempotency_requests_total{outcome="replayed"}[5m]))
+  / sum(rate(idempotency_requests_total[5m]))
+```
+
+Set `idempotency.metrics.enabled=false` to keep the no-op implementation, or register your own
+`IdempotencyMetrics` bean to route the same events somewhere else - the starter backs off from both.
 
 ## Extending
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -73,6 +73,8 @@ public class IdempotencyProperties {
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
 
+    private final Metrics metrics = new Metrics();
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -197,6 +199,10 @@ public class IdempotencyProperties {
         return redis;
     }
 
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
     public Jdbc getJdbc() {
         return jdbc;
     }
@@ -276,6 +282,24 @@ public class IdempotencyProperties {
 
         public void setJoinTransaction(boolean joinTransaction) {
             this.joinTransaction = joinTransaction;
+        }
+    }
+
+    public static class Metrics {
+
+        /**
+         * Publish idempotency counters to Micrometer when a MeterRegistry is present. Set false to
+         * keep the no-op implementation even in an application that has a registry - for instance
+         * where cardinality budgets are tight and these counters are not wanted.
+         */
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 }

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,109 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.metrics.enabled",
+      "description": "Publish idempotency counters to Micrometer when a MeterRegistry is present. All outcomes land on one counter, idempotency.requests, tagged by outcome (executed, replayed, released, conflict, ...). Set false to keep the no-op implementation even in an application that has a registry."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
       ]
     }
   ]

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -14,9 +14,12 @@ dependencies {
 
     compileOnly("org.springframework.data:spring-data-redis")
     compileOnly("org.springframework:spring-jdbc")
+    // Optional: metrics are wired only when the application already has a MeterRegistry.
+    compileOnly("io.micrometer:micrometer-core")
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation("io.micrometer:micrometer-core")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyMetricsAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyMetricsAutoConfiguration.java
@@ -1,0 +1,39 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Wires {@link IdempotencyMetrics} to Micrometer when the application already has a
+ * {@code MeterRegistry}. Nothing to configure: adding {@code spring-boot-starter-actuator} (or any
+ * other source of a registry) is the whole opt-in.
+ *
+ * <p>This is a separate autoconfiguration class rather than a nested one inside
+ * {@link IdempotencyAutoConfiguration} because of ordering. That class contributes the no-op
+ * fallback behind {@code @ConditionalOnMissingBean}, and a nested member class is processed
+ * <em>after</em> its enclosing class's {@code @Bean} methods - the no-op would win the race and the
+ * Micrometer implementation would never be registered. Declaring {@code before} makes the ordering
+ * explicit and load-bearing rather than incidental.
+ *
+ * <p>{@code @ConditionalOnBean(MeterRegistry.class)} and not merely {@code @ConditionalOnClass}:
+ * Micrometer is on the classpath of plenty of applications that never expose a registry, and
+ * injecting one that does not exist would fail startup for something entirely optional.
+ */
+@AutoConfiguration(before = IdempotencyAutoConfiguration.class)
+@ConditionalOnClass(MeterRegistry.class)
+@ConditionalOnProperty(prefix = "idempotency.metrics", name = "enabled", matchIfMissing = true)
+public class IdempotencyMetricsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry.class)
+    @ConditionalOnMissingBean(IdempotencyMetrics.class)
+    public IdempotencyMetrics micrometerIdempotencyMetrics(MeterRegistry registry) {
+        return new MicrometerIdempotencyMetrics(registry);
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/MicrometerIdempotencyMetrics.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/MicrometerIdempotencyMetrics.java
@@ -1,0 +1,109 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer-backed {@link IdempotencyMetrics}, registered automatically when Micrometer and a
+ * {@code MeterRegistry} are both present.
+ *
+ * <p>Everything is recorded on <strong>one</strong> counter, {@code idempotency.requests},
+ * distinguished by an {@code outcome} tag rather than by ten separate meter names. That is the
+ * difference between being able to ask "what fraction of requests were replays?" as a single ratio
+ * and having to hard-code a list of metric names into every dashboard. It also means a new outcome
+ * added later shows up in existing queries instead of being invisible until someone updates them.
+ *
+ * <p>Package-private on purpose: this adds no public API. An application that wants different
+ * meters registers its own {@link IdempotencyMetrics} bean, which the starter backs off from.
+ */
+final class MicrometerIdempotencyMetrics implements IdempotencyMetrics {
+
+    private static final String COUNTER = "idempotency.requests";
+    private static final String DESCRIPTION =
+            "Requests handled by @Idempotent, tagged by what the aspect did with them";
+
+    // Resolved once, not per call. registry.counter(name, tags) is a map lookup plus tag-list
+    // construction on every invocation, and these sit on the request hot path - the aspect calls one
+    // of them for every single request it advises.
+    private final Counter executed;
+    private final Counter replayed;
+    private final Counter replayedAfterWait;
+    private final Counter released;
+    private final Counter conflict;
+    private final Counter waitTimeout;
+    private final Counter fingerprintMismatch;
+    private final Counter missingKey;
+    private final Counter storeFailure;
+    private final Counter principalMissing;
+
+    MicrometerIdempotencyMetrics(MeterRegistry registry) {
+        this.executed = counter(registry, "executed");
+        this.replayed = counter(registry, "replayed");
+        this.replayedAfterWait = counter(registry, "replayed_after_wait");
+        this.released = counter(registry, "released");
+        this.conflict = counter(registry, "conflict");
+        this.waitTimeout = counter(registry, "wait_timeout");
+        this.fingerprintMismatch = counter(registry, "fingerprint_mismatch");
+        this.missingKey = counter(registry, "missing_key");
+        this.storeFailure = counter(registry, "store_failure");
+        this.principalMissing = counter(registry, "principal_missing");
+    }
+
+    private static Counter counter(MeterRegistry registry, String outcome) {
+        return Counter.builder(COUNTER)
+                .description(DESCRIPTION)
+                .tag("outcome", outcome)
+                .register(registry);
+    }
+
+    @Override
+    public void executed() {
+        executed.increment();
+    }
+
+    @Override
+    public void replayed() {
+        replayed.increment();
+    }
+
+    @Override
+    public void replayedAfterWait() {
+        replayedAfterWait.increment();
+    }
+
+    @Override
+    public void released() {
+        released.increment();
+    }
+
+    @Override
+    public void conflict() {
+        conflict.increment();
+    }
+
+    @Override
+    public void waitTimeout() {
+        waitTimeout.increment();
+    }
+
+    @Override
+    public void fingerprintMismatch() {
+        fingerprintMismatch.increment();
+    }
+
+    @Override
+    public void missingKey() {
+        missingKey.increment();
+    }
+
+    @Override
+    public void storeFailure() {
+        storeFailure.increment();
+    }
+
+    @Override
+    public void principalMissing() {
+        principalMissing.increment();
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration
+io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyMetricsAutoConfiguration

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -2,13 +2,17 @@ package io.github.benhendayoussef.idempotency.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
 import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
+import io.github.benhendayoussef.idempotency.internal.NoOpIdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -202,6 +206,61 @@ class IdempotencyAutoConfigurationTest {
                 });
     }
 
+    // --- Micrometer metrics wiring -----------------------------------------------------------
+
+    @Test
+    void noMeterRegistry_keepsTheNoOpMetrics() {
+        // Micrometer is on this test classpath but no registry bean exists - the common shape for an
+        // application that has the jar transitively and never configured actuator. Injecting a
+        // MeterRegistry here would fail startup over something entirely optional.
+        runner.withUserConfiguration(RedisTemplateConfiguration.class)
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(IdempotencyMetrics.class);
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .isInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void aMeterRegistryBeanSwitchesMetricsToMicrometer() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class)
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .as("the Micrometer implementation must win over the no-op fallback, which "
+                                    + "only works because IdempotencyMetricsAutoConfiguration is ordered before")
+                            .isNotInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void metricsCanBeDisabledEvenWithARegistryPresent() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class)
+                .withPropertyValues("idempotency.metrics.enabled=false")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .isInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void aUserSuppliedMetricsBeanStillWins() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class,
+                        CustomMetricsConfiguration.class)
+                .run(ctx -> assertThat(ctx.getBean(IdempotencyMetrics.class))
+                        .isSameAs(CustomMetricsConfiguration.CUSTOM));
+    }
+
+    /** The default runner does not load the metrics autoconfiguration; these cases need it. */
+    private WebApplicationContextRunner metricsRunner() {
+        return new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(
+                IdempotencyMetricsAutoConfiguration.class,
+                IdempotencyAutoConfiguration.class,
+                IdempotencyStoreFallbackAutoConfiguration.class));
+    }
+
     // --- idempotency.jdbc.join-transaction wiring (C4/C5/C6) ---------------------------------
 
     @Test
@@ -289,7 +348,8 @@ class IdempotencyAutoConfigurationTest {
         }
         assertThat(lines).containsExactlyInAnyOrder(
                 "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration",
-                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration");
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration",
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyMetricsAutoConfiguration");
     }
 
     @Test
@@ -392,6 +452,25 @@ class IdempotencyAutoConfigurationTest {
             template.setConnectionFactory(factory);
             template.afterPropertiesSet();
             return template;
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MeterRegistryConfiguration {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomMetricsConfiguration {
+        static final IdempotencyMetrics CUSTOM = new IdempotencyMetrics() {
+        };
+
+        @Bean
+        IdempotencyMetrics idempotencyMetrics() {
+            return CUSTOM;
         }
     }
 }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
@@ -1,0 +1,139 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * The counters must move for real requests through the real HTTP/AOP path, against a real
+ * {@link MeterRegistry} - not a mock. A metrics implementation that compiles but never increments
+ * is the classic way observability silently fails, and it fails quietly enough that nobody notices
+ * until they need a dashboard during an incident.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = {AbstractIdempotencyBehaviorTest.TestApp.class,
+                MicrometerMetricsBehaviorTest.MeterRegistryConfiguration.class},
+        properties = {"idempotency.store=memory",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+@AutoConfigureMockMvc
+class MicrometerMetricsBehaviorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MeterRegistry registry;
+
+    @Autowired
+    private AbstractIdempotencyBehaviorTest.MatrixController controller;
+
+    private double count(String outcome) {
+        var counter = registry.find("idempotency.requests").tag("outcome", outcome).counter();
+        return counter == null ? 0d : counter.count();
+    }
+
+    @Test
+    void firstCallCountsAsExecutedAndTheDuplicateAsReplayed() throws Exception {
+        double executedBefore = count("executed");
+        double replayedBefore = count("replayed");
+        String key = "metrics-" + System.nanoTime();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(count("executed") - executedBefore).isEqualTo(1d);
+        assertThat(count("replayed") - replayedBefore).isZero();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(count("replayed") - replayedBefore)
+                .as("the duplicate is a replay, and must not also count as an execution").isEqualTo(1d);
+        assertThat(count("executed") - executedBefore).isEqualTo(1d);
+    }
+
+    @Test
+    void aRequestWithNoKeyCountsAsMissingKey() throws Exception {
+        double before = count("missing_key");
+        mockMvc.perform(post("/m/echo").contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+        assertThat(count("missing_key") - before).isEqualTo(1d);
+    }
+
+    @Test
+    void a5xxReleasesTheKeyAndCountsAsReleased() throws Exception {
+        double before = count("released");
+        String key = "metrics-released-" + System.nanoTime();
+
+        // /m/flaky throws a 500-mapped exception on the armed call, which the failure policy
+        // releases so a retry can re-execute.
+        controller.armFailNextInfra();
+
+        mockMvc.perform(post("/m/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isInternalServerError());
+
+        assertThat(count("released") - before).isEqualTo(1d);
+    }
+
+    @Test
+    void aDifferentBodyOnTheSameKeyCountsAsAFingerprintMismatch() throws Exception {
+        double before = count("fingerprint_mismatch");
+        String key = "metrics-fp-" + System.nanoTime();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":999}"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(count("fingerprint_mismatch") - before).isEqualTo(1d);
+    }
+
+    /**
+     * Every outcome shares one meter name, so a dashboard can express "replay rate" as a ratio over
+     * a single series instead of hard-coding a list of metric names. Asserting the shape here means
+     * a future outcome added as its own meter name breaks this test rather than silently splitting
+     * the series.
+     */
+    @Test
+    void allOutcomesShareASingleCounterNameDistinguishedByTag() throws Exception {
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", "shape-" + System.nanoTime())
+                .contentType("application/json").content("{\"a\":1}"));
+
+        var meters = registry.find("idempotency.requests").counters();
+        assertThat(meters).isNotEmpty();
+        assertThat(meters)
+                .allSatisfy(c -> assertThat(c.getId().getTag("outcome"))
+                        .as("every idempotency.requests counter must carry an outcome tag")
+                        .isNotNull());
+        assertThat(registry.getMeters())
+                .filteredOn(m -> m.getId().getName().startsWith("idempotency."))
+                .allSatisfy(m -> assertThat(m.getId().getName())
+                        .as("no idempotency meter may use a name other than the single shared counter")
+                        .isEqualTo("idempotency.requests"));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MeterRegistryConfiguration {
+        // A real registry, not a mock: SimpleMeterRegistry actually accumulates values, so the
+        // assertions above test the counters rather than testing that a mock was called.
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+}


### PR DESCRIPTION
Second of the six items scoped for 0.3.0. Independent of #4 — both branch from `main`.

## What was missing

`IdempotencyMetrics` has been called from the aspect since 0.1, at all ten interesting points. It just had no implementation but the no-op, so nothing was observable unless an application wrote its own. This wires it to Micrometer.

**Opt-in is having a `MeterRegistry`** — `spring-boot-starter-actuator` is enough. Nothing to configure.

## One counter, not ten

Everything lands on `idempotency.requests`, separated by an `outcome` tag: `executed`, `replayed`, `replayed_after_wait`, `released`, `conflict`, `wait_timeout`, `fingerprint_mismatch`, `missing_key`, `store_failure`, `principal_missing`.

That shape is the main design decision here. It's the difference between

```promql
sum(rate(idempotency_requests_total{outcome="replayed"}[5m]))
  / sum(rate(idempotency_requests_total[5m]))
```

and hard-coding a list of ten metric names into every dashboard. It also means an outcome added in a later version shows up in existing queries rather than being invisible until someone updates them. A test asserts the shape, so a future outcome added as its own meter name breaks the build instead of silently splitting the series.

## Two things worth reviewing

**Ordering.** This is a separate autoconfiguration class declared `before = IdempotencyAutoConfiguration.class`, not a nested one. That class contributes the no-op behind `@ConditionalOnMissingBean`, and a nested member class is processed *after* its enclosing class's `@Bean` methods — the no-op would win the race and the Micrometer implementation would never register. Making the ordering explicit rather than incidental is the whole reason for the extra file.

**`@ConditionalOnBean(MeterRegistry.class)`, not just `@ConditionalOnClass`.** Micrometer is on the classpath of plenty of applications that never expose a registry; injecting one that doesn't exist would fail startup over something entirely optional. There's a test for exactly that case.

**Hot path.** Counters are resolved once in the constructor. `registry.counter(name, tags)` is a map lookup plus tag-list construction, and one of these fires on every advised request.

## Tests

`MicrometerMetricsBehaviorTest` runs against a real `SimpleMeterRegistry` through the real HTTP/AOP path — not a mock. A metrics implementation that compiles but never increments is the classic silent observability failure, and asserting on a mock wouldn't catch it. It covers execute vs replay, missing key, the 5xx release, the fingerprint-mismatch 422, and the single-counter shape.

Four wiring tests cover: no registry → no-op kept; registry → Micrometer wins; `idempotency.metrics.enabled=false` → no-op kept; user-supplied bean still wins.

`./gradlew clean build` green.

## API surface

None added. `MicrometerIdempotencyMetrics` is package-private; the only new public thing is the `idempotency.metrics.enabled` property, with configuration metadata.

## Note on merge order

This branches from `main`, as does #4. Both touch `IdempotencyAutoConfiguration` and `IdempotencyAutoConfigurationTest`, so whichever merges second may need a trivial rebase. Merging #4 first is the easier order, since its `MockMvcTestConfiguration` then applies to the new test here too — this PR currently uses `@AutoConfigureMockMvc` to match `main`.
