### PR TITLE
Add MySQL and MariaDB support to the JDBC store

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ spring:
   sql:
     init:
       mode: always
-      schema-locations: classpath:db/idempotency/postgres.sql # ships inside idempotency-store-jdbc
+      schema-locations: classpath:db/idempotency/postgres.sql # or mysql.sql - both ship inside idempotency-store-jdbc
 idempotency:
   store: jdbc   # required: AUTO never selects JDBC on its own, even with no Redis present
 ```
@@ -127,17 +127,18 @@ a silent execution of the wrong payload.
 | `idempotency.release-on` | `five_xx,timeout` | Outcomes that release instead of complete the key. Note the underscore: Spring's relaxed binding needs `five_xx`, not `5xx` |
 | `idempotency.redis.key-prefix` | `idempotency:` | |
 | `idempotency.jdbc.table-name` | `idempotency_record` | |
+| `idempotency.jdbc.dialect` | `auto` | `auto` | `postgres` | `mysql`. AUTO detects from the `DataSource` on first use, not at startup |
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
 | `idempotency.jdbc.sweeper-interval` | `15m` | |
 | `idempotency.jdbc.join-transaction` | `false` | Run the handler and the completion write in one shared transaction — exactly-once instead of at-least-once. Costs: non-`@Transactional` handlers get pulled into a transaction, and a handler's own `@Transactional(timeout)` stops applying. [Read the caveats first](#opt-in-exactly-once-via-transaction-joining) |
 
 ## Store comparison
 
-| | Redis | JDBC (Postgres) |
+| | Redis | JDBC (Postgres / MySQL) |
 |---|---|---|
 | Guarantee | **At-least-once.** If the process crashes between the business transaction committing and the completion record being written, the key stays `IN_PROGRESS` until TTL and a retry re-executes. | **At-least-once by default; exactly-once with `idempotency.jdbc.join-transaction=true`.** Both modes are described below — read them before switching. |
 | Speed | Fast — a single round trip per claim. | Slower — shares the datasource and transaction. |
-| Setup | `spring-boot-starter-data-redis` | A `DataSource`, `idempotency.store=jdbc`, and `db/idempotency/postgres.sql` applied — see the JDBC quickstart above |
+| Setup | `spring-boot-starter-data-redis` | A `DataSource`, `idempotency.store=jdbc`, and the schema for your database applied — see the JDBC quickstart above |
 | Good for | The other 95% of use cases. | Payments and anything else where a replayed side effect is unacceptable, **if you use it the way described below.** |
 
 **Measured overhead** (200 requests, 20 warmup iterations, real Redis/Postgres via Testcontainers on
@@ -253,7 +254,7 @@ Being loud about these is what makes a library trustworthy:
   anything the handler writes directly to `HttpServletResponse` is not captured.
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
-- Postgres only for the JDBC store (MySQL is on the roadmap).
+- The JDBC store supports PostgreSQL and MySQL/MariaDB. Other engines need a new dialect.
 - Servlet stack only (WebFlux is on the roadmap).
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -209,6 +209,8 @@ public class IdempotencyProperties {
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
 
+    public enum Dialect { AUTO, POSTGRES, MYSQL }
+
     public static class Redis {
 
         /** Prefix applied to every Redis key the store writes. */
@@ -246,6 +248,14 @@ public class IdempotencyProperties {
          */
         private boolean joinTransaction = false;
 
+        /**
+         * Which SQL dialect the store speaks. AUTO asks the DataSource what it is connected to at
+         * startup, which is right almost always; set it explicitly for a database that reports a
+         * product name AUTO does not recognise, or to fail fast on a misconfigured DataSource
+         * rather than silently getting the wrong SQL.
+         */
+        private Dialect dialect = Dialect.AUTO;
+
         public String getTableName() {
             return tableName;
         }
@@ -268,6 +278,14 @@ public class IdempotencyProperties {
 
         public void setSweeperInterval(Duration sweeperInterval) {
             this.sweeperInterval = sweeperInterval;
+        }
+
+        public Dialect getDialect() {
+            return dialect;
+        }
+
+        public void setDialect(Dialect dialect) {
+            this.dialect = dialect;
         }
 
         public boolean isJoinTransaction() {

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,126 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.jdbc.dialect",
+      "description": "Which SQL dialect the JDBC store speaks. AUTO asks the DataSource what database it is connected to, on first use rather than at startup. Set explicitly to skip detection."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
+      ]
+    },
+    {
+      "name": "idempotency.jdbc.dialect",
+      "values": [
+        {
+          "value": "auto",
+          "description": "Detect from the DataSource on first use."
+        },
+        {
+          "value": "postgres",
+          "description": "PostgreSQL."
+        },
+        {
+          "value": "mysql",
+          "description": "MySQL or MariaDB."
+        }
       ]
     }
   ]

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:mysql")
+    testRuntimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.postgresql:postgresql")
 }
 

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -22,7 +22,12 @@ import io.github.benhendayoussef.idempotency.internal.scope.PrincipalScopeResolv
 import io.github.benhendayoussef.idempotency.internal.scope.TenantScopeResolver;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencyRecordSweeper;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySweeperScheduler;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.LazySqlDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.MySqlDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.PostgresDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.SqlDialectResolver;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcTransactionRunner;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.util.EnumMap;
@@ -188,10 +193,27 @@ public class IdempotencyAutoConfiguration {
     static class JdbcStoreConfiguration {
 
         @Bean
+        @ConditionalOnMissingBean(IdempotencySqlDialect.class)
+        @ConditionalOnBean(DataSource.class)
+        IdempotencySqlDialect idempotencySqlDialect(DataSource dataSource, IdempotencyProperties props) {
+            return switch (props.getJdbc().getDialect()) {
+                case POSTGRES -> new PostgresDialect();
+                case MYSQL -> new MySqlDialect();
+                // Detection opens one connection at startup. That is a deliberate trade: the
+                // alternative is discovering the wrong SQL was chosen from a duplicate execution
+                // in production, which is untraceable back to here.
+                case AUTO -> new LazySqlDialect(dataSource);
+            };
+        }
+
+        @Bean
         @ConditionalOnMissingBean(IdempotencyStore.class)
         @ConditionalOnBean(DataSource.class)
-        IdempotencyStore jdbcIdempotencyStore(DataSource dataSource, IdempotencyProperties props) {
-            return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), props.getJdbc().getTableName());
+        IdempotencyStore jdbcIdempotencyStore(DataSource dataSource, IdempotencyProperties props,
+                IdempotencySqlDialect dialect) {
+            log.debug("Idempotency JDBC store using the {} dialect", dialect.name());
+            return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource),
+                    props.getJdbc().getTableName(), dialect);
         }
 
         @Bean

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.io.IOException;
@@ -199,6 +200,35 @@ class IdempotencyAutoConfigurationTest {
                     assertThat(props.getReleaseOn())
                             .containsExactlyInAnyOrder(IdempotencyProperties.ReleaseOn.FIVE_XX,
                                     IdempotencyProperties.ReleaseOn.TIMEOUT);
+                });
+    }
+
+    // --- SQL dialect selection ---------------------------------------------------------------
+
+    @Test
+    void dialectAutoDetectionDoesNotTouchTheDatabaseAtStartup() {
+        // DataSourceConfiguration points at a Postgres that is not running. Startup must still
+        // succeed: an unreachable database is a request-time condition that
+        // idempotency.on-store-failure decides what to do about, and detecting the dialect eagerly
+        // would promote it to a startup failure and take the application down instead.
+        runner.withUserConfiguration(DataSourceConfiguration.class)
+                .withPropertyValues("idempotency.store=jdbc")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(IdempotencySqlDialect.class);
+                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name())
+                            .as("resolving the name must not be what forces a connection either")
+                            .isEqualTo("auto (not yet resolved)");
+                });
+    }
+
+    @Test
+    void anExplicitDialectSkipsDetectionEntirely() {
+        runner.withUserConfiguration(DataSourceConfiguration.class)
+                .withPropertyValues("idempotency.store=jdbc", "idempotency.jdbc.dialect=mysql")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name()).isEqualTo("MySQL");
                 });
     }
 

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
@@ -1,0 +1,143 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.internal.IdempotencyKeyComposer;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The full behavioural matrix against a real MySQL, plus the dialect-specific cases below.
+ *
+ * <p>Running the whole inherited suite rather than a handful of smoke tests is the point: the
+ * differences between the two dialects are in claim semantics and expiry comparison, which is
+ * exactly what the matrix exercises hardest - concurrency, TTL, fingerprint mismatch, the failure
+ * policy. A MySQL-specific bug would show up as a wrong answer under one of those, not as a SQL
+ * syntax error.
+ */
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = AbstractIdempotencyBehaviorTest.TestApp.class,
+        properties = {
+                "idempotency.store=jdbc",
+                "spring.sql.init.mode=always",
+                "spring.sql.init.schema-locations=classpath:db/idempotency/mysql.sql",
+                TestAutoconfigExcludes.EXCLUDE_SECURITY
+        })
+class MySqlIdempotencyBehaviorTest extends AbstractIdempotencyBehaviorTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4");
+
+    @DynamicPropertySource
+    static void mysqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+    }
+
+    @Autowired
+    private IdempotencySqlDialect dialect;
+
+    @Autowired
+    private IdempotencyStore store;
+
+    @Autowired
+    private IdempotencyKeyComposer composer;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void autoDetectionPicksTheMySqlDialectWithoutBeingTold() throws Exception {
+        // idempotency.jdbc.dialect is left at AUTO above, so this asserts detection rather than
+        // configuration - the case every MySQL user actually hits.
+        //
+        // Detection is deferred until the store is first used; that laziness is asserted in
+        // IdempotencyAutoConfigurationTest, which can use a fresh context. Here the context is
+        // shared with the inherited suite, so the dialect may already be resolved - what this test
+        // proves is that detection reached the right answer against a real MySQL.
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", "detect-" + System.nanoTime())
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(dialect.name()).isEqualTo("MySQL");
+    }
+
+    /**
+     * The reclaim path, which is where the two dialects diverge most. Postgres expresses it as
+     * {@code ON CONFLICT ... WHERE expired}; MySQL has to push the condition into every assignment,
+     * and the update reports 2 affected rows rather than 1.
+     *
+     * <p>A dialect that got the affected-row reading wrong would fail here specifically: the caller
+     * would be told the key is already held by a row it just wrote itself, and get a 409 instead of
+     * executing.
+     */
+    @Test
+    void anExpiredRowIsReclaimedByTheNextClaimRatherThanConflicting() throws Exception {
+        String key = "mysql-reclaim-" + System.nanoTime();
+        String storageKey = storageKeyFor(key);
+
+        var first = store.claim(storageKey, "fp", Duration.ofMillis(200));
+        assertThat(first).isInstanceOf(IdempotencyStore.ClaimResult.Acquired.class);
+
+        Thread.sleep(400);
+
+        var second = store.claim(storageKey, "fp", Duration.ofSeconds(30));
+        assertThat(second)
+                .as("the row had expired, so this claim must reclaim it - not report a conflict")
+                .isInstanceOf(IdempotencyStore.ClaimResult.Acquired.class);
+
+        assertThat(store.find(storageKey)).isPresent().get()
+                .extracting(io.github.benhendayoussef.idempotency.api.IdempotencyRecord::state)
+                .isEqualTo(State.IN_PROGRESS);
+    }
+
+    /**
+     * The other half of the same statement: a <em>live</em> row must be left completely untouched.
+     * MySQL applies the assignments left to right, so a guard ordering mistake would half-apply the
+     * reclaim here - wiping the stored payload of a record someone is about to replay - while still
+     * reporting a conflict, which no status-code assertion would catch.
+     */
+    @Test
+    void aLiveRecordIsNotModifiedByACompetingClaim() throws Exception {
+        String key = "mysql-live-" + System.nanoTime();
+        String storageKey = storageKeyFor(key);
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        var before = store.find(storageKey).orElseThrow();
+        assertThat(before.state()).isEqualTo(State.COMPLETED);
+
+        // A competing claim on the same live key: must change nothing at all.
+        store.claim(storageKey, "different-fingerprint", Duration.ofSeconds(30));
+
+        var after = store.find(storageKey).orElseThrow();
+        assertThat(after.state()).as("a live COMPLETED record must survive a competing claim")
+                .isEqualTo(State.COMPLETED);
+        assertThat(after.fingerprint()).isEqualTo(before.fingerprint());
+        assertThat(after.payload()).isEqualTo(before.payload());
+        assertThat(after.status()).isEqualTo(before.status());
+    }
+
+    private String storageKeyFor(String clientKey) {
+        var request = new org.springframework.mock.web.MockHttpServletRequest("POST", "/m/echo");
+        request.setAttribute(org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/m/echo");
+        return composer.compose(clientKey, "", request);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/IdempotencySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/IdempotencySqlDialect.java
@@ -1,0 +1,56 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * The database-specific half of {@link JdbcIdempotencyStore}.
+ *
+ * <p>Only four statements differ between engines, but one of them - the claim - is the whole
+ * correctness argument of this library, so it is worth being explicit about what a dialect has to
+ * guarantee rather than treating this as string templating.
+ *
+ * <p><strong>The claim must be atomic</strong>: no read-then-write window, and two concurrent
+ * duplicates must never both be told they acquired the key. An expired row must be reclaimable by
+ * the claim itself, or a key whose owner crashed would stay locked until a sweeper happened to
+ * run. How many statements that takes is the dialect's business - see {@link #tryAcquire}.
+ *
+ * <p>Dialects must also agree on "now". Every expiry decision is made by the database, never the
+ * JVM: with several application instances and any clock skew, comparing against each instance's own
+ * {@code Instant.now()} would make the same row look expired on one and live on another. The
+ * function chosen must additionally be one that advances <em>within</em> a transaction - Postgres's
+ * {@code now()} is frozen at transaction start, which is why {@code clock_timestamp()} is used
+ * there.
+ *
+ * <p>Public only because Spring auto-configuration in another module selects an implementation.
+ * Like everything in this package it is <strong>not part of the supported API</strong>.
+ */
+public interface IdempotencySqlDialect {
+
+    /** Human-readable name, used in startup logging and failure messages. */
+    String name();
+
+    /**
+     * Atomically take the key, or report that someone else holds it.
+     *
+     * <p>This is a method rather than a SQL string because the two engines need genuinely different
+     * <em>algorithms</em>, not merely different syntax. Postgres can express the whole thing as one
+     * statement whose affected-row count is trustworthy; MySQL cannot, because its JDBC driver
+     * defaults to reporting <em>matched</em> rather than <em>changed</em> rows, which makes an
+     * unchanged duplicate indistinguishable from a fresh insert. Hiding that behind a shared
+     * template would have meant every MySQL duplicate silently executing.
+     *
+     * @return {@code true} if this caller now owns the key - either freshly inserted, or reclaimed
+     *         from an expired row. {@code false} means a live row is held by someone else.
+     */
+    boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id, String fingerprint,
+            long ttlMillis);
+
+    /** Parameters: {@code :id}, {@code :fp}, {@code :status}, {@code :payloadType}, {@code :payload}, {@code :ttlMillis}. */
+    String completeSql(String tableName);
+
+    /** Parameters: {@code :id}. */
+    String releaseSql(String tableName);
+
+    /** Parameters: {@code :id}. Must not return rows that have already expired. */
+    String findSql(String tableName);
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStore.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStore.java
@@ -35,48 +35,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcIdempotencyStore implements IdempotencyStore {
 
     private final NamedParameterJdbcTemplate jdbc;
-    private final String claimSql;
-    private final String completeSql;
-    private final String releaseSql;
-    private final String findSql;
+    // Memoized rather than built in the constructor: with dialect=auto the dialect has not
+    // been resolved yet at construction time, and asking it for SQL would force a database
+    // connection during startup - see LazySqlDialect for why that must not happen.
+    private volatile String completeSql;
+    private volatile String releaseSql;
+    private volatile String findSql;
     private final RowMapper<IdempotencyRecord> rowMapper = this::mapRow;
 
-    public JdbcIdempotencyStore(NamedParameterJdbcTemplate jdbc, String tableName) {
+    private final IdempotencySqlDialect dialect;
+
+    private final String tableName;
+
+    public JdbcIdempotencyStore(NamedParameterJdbcTemplate jdbc, String tableName,
+            IdempotencySqlDialect dialect) {
         this.jdbc = jdbc;
-        this.claimSql = """
-                INSERT INTO %s
-                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
-                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, clock_timestamp(),
-                        clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond'))
-                ON CONFLICT (id) DO UPDATE SET
-                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
-                    payload_type = NULL, payload = NULL, created_at = clock_timestamp(),
-                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
-                WHERE %s.expires_at < clock_timestamp()
-                """.formatted(tableName, tableName);
-        this.completeSql = """
-                UPDATE %s SET
-                    state = 'COMPLETED', fingerprint = :fp, status = :status,
-                    payload_type = :payloadType, payload = :payload,
-                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
-                WHERE id = :id
-                """.formatted(tableName);
-        this.releaseSql = "DELETE FROM %s WHERE id = :id".formatted(tableName);
-        this.findSql = """
-                SELECT state, fingerprint, status, payload_type, payload, created_at
-                FROM %s WHERE id = :id AND expires_at >= clock_timestamp()
-                """.formatted(tableName);
+        this.dialect = dialect;
+        this.tableName = tableName;
     }
 
     @Override
     public ClaimResult claim(String key, String fingerprint, Duration ttl) {
-        int rows = jdbc.update(claimSql, new MapSqlParameterSource()
-                .addValue("id", key)
-                .addValue("fp", fingerprint)
-                .addValue("ttlMillis", ttl.toMillis()));
-        if (rows == 1) {
+        if (dialect.tryAcquire(jdbc, tableName, key, fingerprint, ttl.toMillis())) {
             return new ClaimResult.Acquired();
         }
+        // Lost the claim, so read back whoever holds it. The Optional can still be empty if that
+        // row expired or was released in the gap - in which case nobody holds the key any more and
+        // the caller is free to proceed.
         return find(key)
                 .<ClaimResult>map(ClaimResult.AlreadyHeld::new)
                 .orElseGet(ClaimResult.Acquired::new);
@@ -85,7 +70,7 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public void complete(String key, IdempotencyRecord record, Duration ttl) {
-        jdbc.update(completeSql, new MapSqlParameterSource()
+        jdbc.update(completeSql(), new MapSqlParameterSource()
                 .addValue("id", key)
                 .addValue("fp", record.fingerprint())
                 .addValue("status", record.status())
@@ -97,13 +82,28 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void release(String key) {
-        jdbc.update(releaseSql, Map.of("id", key));
+        jdbc.update(releaseSql(), Map.of("id", key));
     }
 
     @Override
     public Optional<IdempotencyRecord> find(String key) {
-        var rows = jdbc.query(findSql, new MapSqlParameterSource().addValue("id", key), rowMapper);
+        var rows = jdbc.query(findSql(), new MapSqlParameterSource().addValue("id", key), rowMapper);
         return rows.stream().findFirst();
+    }
+
+    private String completeSql() {
+        String sql = completeSql;
+        return sql != null ? sql : (completeSql = dialect.completeSql(tableName));
+    }
+
+    private String releaseSql() {
+        String sql = releaseSql;
+        return sql != null ? sql : (releaseSql = dialect.releaseSql(tableName));
+    }
+
+    private String findSql() {
+        String sql = findSql;
+        return sql != null ? sql : (findSql = dialect.findSql(tableName));
     }
 
     private IdempotencyRecord mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/LazySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/LazySqlDialect.java
@@ -1,0 +1,72 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Auto-detection that does not touch the database until the first request needs it.
+ *
+ * <p>Detecting eagerly, at bean creation, seems harmless and is not: it opens a connection during
+ * startup, so a database that is merely slow to come up - or deliberately unreachable, which is the
+ * documented {@code idempotency.on-store-failure=proceed} scenario - takes the whole application
+ * down instead of degrading the way it is supposed to. Resolving on first use keeps an unreachable
+ * store a <em>request-time</em> condition, which is where the failure policy can act on it.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public final class LazySqlDialect implements IdempotencySqlDialect {
+
+    private final DataSource dataSource;
+    private volatile IdempotencySqlDialect resolved;
+
+    public LazySqlDialect(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    private IdempotencySqlDialect delegate() {
+        IdempotencySqlDialect local = resolved;
+        if (local == null) {
+            synchronized (this) {
+                local = resolved;
+                if (local == null) {
+                    local = SqlDialectResolver.detect(dataSource);
+                    resolved = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    /**
+     * Deliberately does not resolve. This is used for logging, and a log line is not a good enough
+     * reason to open a database connection - least of all during startup, which is the thing this
+     * class exists to avoid.
+     */
+    @Override
+    public String name() {
+        IdempotencySqlDialect local = resolved;
+        return local == null ? "auto (not yet resolved)" : local.name();
+    }
+
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        return delegate().tryAcquire(jdbc, tableName, id, fingerprint, ttlMillis);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return delegate().completeSql(tableName);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return delegate().releaseSql(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return delegate().findSql(tableName);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/MySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/MySqlDialect.java
@@ -1,0 +1,117 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * MySQL and MariaDB.
+ *
+ * <p>{@code CURRENT_TIMESTAMP(6)} is the counterpart to Postgres's {@code clock_timestamp()}: MySQL
+ * evaluates it per statement rather than freezing it for the transaction, which is the property the
+ * claim needs. The {@code (6)} matters - without it MySQL truncates to whole seconds, so a TTL
+ * shorter than a second would round to nothing and two claims in the same second would compare as
+ * equal.
+ */
+public final class MySqlDialect implements IdempotencySqlDialect {
+
+    private static final String EXPIRY =
+            "DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL (:ttlMillis * 1000) MICROSECOND)";
+
+    @Override
+    public String name() {
+        return "MySQL";
+    }
+
+    /**
+     * Reclaim-then-insert, rather than the single {@code INSERT ... ON DUPLICATE KEY UPDATE} the
+     * Postgres dialect's shape would suggest.
+     *
+     * <p>The obvious upsert does not work here, and fails in the worst possible way. Connector/J
+     * defaults to {@code useAffectedRows=false}, which sets {@code CLIENT_FOUND_ROWS} and makes the
+     * driver report <em>matched</em> rows instead of <em>changed</em> ones. A duplicate that
+     * deliberately changed nothing then reports 1 - identical to a fresh insert - so every duplicate
+     * reads as a successful claim and executes. That is not a subtle degradation; it is the library
+     * doing the exact opposite of its job, and it depends on a connection-string option the
+     * application owns rather than this code.
+     *
+     * <p>Both statements below are immune to that, because each is conditional in its own
+     * {@code WHERE} clause rather than in its update count:
+     *
+     * <ol>
+     *   <li>The {@code UPDATE} matches only an <em>expired</em> row. A live row is excluded by the
+     *       predicate, so it matches zero rows under either driver mode. When it does match, it
+     *       always changes values, so matched and changed agree.</li>
+     *   <li>If nothing was reclaimed, the {@code INSERT} either succeeds - the key was absent - or
+     *       violates the primary key, which Spring surfaces as {@link DuplicateKeyException}. That
+     *       is an exception, not a count, so no driver setting can blur it.</li>
+     * </ol>
+     *
+     * <p>Concurrency holds because InnoDB takes a row lock for the {@code UPDATE} and a unique-index
+     * lock for the {@code INSERT}. Two callers racing an expired row: the first reclaims it and
+     * pushes {@code expires_at} into the future, so the second no longer matches the predicate, falls
+     * through, and collides on the primary key. Exactly one wins.
+     */
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        var params = new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("fp", fingerprint)
+                .addValue("ttlMillis", ttlMillis);
+
+        if (jdbc.update(reclaimExpiredSql(tableName), params) > 0) {
+            return true;
+        }
+        try {
+            jdbc.update(insertSql(tableName), params);
+            return true;
+        } catch (DuplicateKeyException alreadyHeld) {
+            // Someone else holds a live row. The caller reads it back to build the AlreadyHeld
+            // result; swallowing the exception here is the whole signal.
+            return false;
+        }
+    }
+
+    private String reclaimExpiredSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
+                    payload_type = NULL, payload = NULL, created_at = CURRENT_TIMESTAMP(6),
+                    expires_at = %s
+                WHERE id = :id AND expires_at < CURRENT_TIMESTAMP(6)
+                """.formatted(tableName, EXPIRY);
+    }
+
+    private String insertSql(String tableName) {
+        return """
+                INSERT INTO %s
+                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
+                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, CURRENT_TIMESTAMP(6), %s)
+                """.formatted(tableName, EXPIRY);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'COMPLETED', fingerprint = :fp, status = :status,
+                    payload_type = :payloadType, payload = :payload,
+                    expires_at = %s
+                WHERE id = :id
+                """.formatted(tableName, EXPIRY);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return "DELETE FROM %s WHERE id = :id".formatted(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return """
+                SELECT state, fingerprint, status, payload_type, payload, created_at
+                FROM %s WHERE id = :id AND expires_at >= CURRENT_TIMESTAMP(6)
+                """.formatted(tableName);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/PostgresDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/PostgresDialect.java
@@ -1,0 +1,75 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Postgres. The original dialect, extracted from {@link JdbcIdempotencyStore} unchanged when MySQL
+ * support was added - the SQL here is byte-for-byte what shipped in 0.1 and 0.2.
+ *
+ * <p>{@code clock_timestamp()} and not {@code now()}: the latter is frozen at transaction start, so
+ * a long-running transaction would keep comparing against a stale "now" and see expired rows as
+ * live.
+ */
+public final class PostgresDialect implements IdempotencySqlDialect {
+
+    @Override
+    public String name() {
+        return "PostgreSQL";
+    }
+
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        int rows = jdbc.update(claimSql(tableName), new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("fp", fingerprint)
+                .addValue("ttlMillis", ttlMillis));
+        // Postgres reports exactly one row for both the insert and the reclaiming update, and
+        // zero when the WHERE excluded a live row. The pgjdbc driver has no found-rows mode, so
+        // unlike MySQL this count means what it says.
+        return rows == 1;
+    }
+
+    private String claimSql(String tableName) {
+        // ON CONFLICT ... DO UPDATE ... WHERE is the whole trick: the WHERE is evaluated against the
+        // existing row, so a live row matches nothing and the statement reports zero rows without
+        // ever touching it.
+        return """
+                INSERT INTO %s
+                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
+                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, clock_timestamp(),
+                        clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond'))
+                ON CONFLICT (id) DO UPDATE SET
+                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
+                    payload_type = NULL, payload = NULL, created_at = clock_timestamp(),
+                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
+                WHERE %s.expires_at < clock_timestamp()
+                """.formatted(tableName, tableName);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'COMPLETED', fingerprint = :fp, status = :status,
+                    payload_type = :payloadType, payload = :payload,
+                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
+                WHERE id = :id
+                """.formatted(tableName);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return "DELETE FROM %s WHERE id = :id".formatted(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return """
+                SELECT state, fingerprint, status, payload_type, payload, created_at
+                FROM %s WHERE id = :id AND expires_at >= clock_timestamp()
+                """.formatted(tableName);
+    }
+
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolver.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolver.java
@@ -1,0 +1,61 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Locale;
+import javax.sql.DataSource;
+
+/**
+ * Picks the {@link IdempotencySqlDialect} for a {@code DataSource}, either from an explicit setting
+ * or by asking the database what it is.
+ *
+ * <p>Detection happens once, at startup, and fails loudly. A store that silently guessed wrong would
+ * not throw - it would issue SQL the engine happens to accept and get the claim semantics subtly
+ * wrong, which surfaces as duplicate executions under concurrency rather than as an error anyone
+ * could trace back here.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public final class SqlDialectResolver {
+
+    private SqlDialectResolver() {
+    }
+
+    /** Detects the dialect from the connection's reported product name. */
+    public static IdempotencySqlDialect detect(DataSource dataSource) {
+        String product;
+        try (Connection connection = dataSource.getConnection()) {
+            product = connection.getMetaData().getDatabaseProductName();
+        } catch (SQLException e) {
+            throw new IllegalStateException(
+                    "idempotency.store=jdbc with idempotency.jdbc.dialect=auto could not connect to the "
+                    + "DataSource to detect which database it is. Fix the DataSource, or set "
+                    + "idempotency.jdbc.dialect explicitly (postgres or mysql) to skip detection.", e);
+        }
+        return forProductName(product);
+    }
+
+    /**
+     * Maps a JDBC product name to a dialect.
+     *
+     * <p>MariaDB reports itself as "MariaDB" but is wire- and SQL-compatible with MySQL for
+     * everything the claim uses, including {@code ON DUPLICATE KEY UPDATE} and
+     * {@code CURRENT_TIMESTAMP(6)}, so it maps to the same dialect. Amazon Aurora reports the engine
+     * it emulates, so it needs no special case.
+     */
+    static IdempotencySqlDialect forProductName(String productName) {
+        String normalized = productName == null ? "" : productName.toLowerCase(Locale.ROOT);
+        if (normalized.contains("postgresql")) {
+            return new PostgresDialect();
+        }
+        if (normalized.contains("mysql") || normalized.contains("mariadb")) {
+            return new MySqlDialect();
+        }
+        throw new IllegalStateException(
+                "Unsupported database for idempotency.store=jdbc: the DataSource reports itself as \""
+                + productName + "\", and only PostgreSQL and MySQL/MariaDB are implemented. Set "
+                + "idempotency.jdbc.dialect explicitly if this database is compatible with one of "
+                + "them, or use idempotency.store=redis.");
+    }
+}

--- a/idempotency-store-jdbc/src/main/resources/db/idempotency/mysql.sql
+++ b/idempotency-store-jdbc/src/main/resources/db/idempotency/mysql.sql
@@ -1,0 +1,23 @@
+-- MySQL / MariaDB schema. Apply the same way as postgres.sql:
+--   spring.sql.init.schema-locations=classpath:db/idempotency/mysql.sql
+--
+-- DATETIME(6), not TIMESTAMP: TIMESTAMP is limited to 2038 and silently converts through the
+-- session time zone on both write and read, which would make expiry depend on the connecting
+-- client's zone. Expiry is decided entirely server-side by comparing against CURRENT_TIMESTAMP(6),
+-- so the column only has to be consistent with itself.
+--
+-- The (6) is not decorative. Without it MySQL truncates to whole seconds, so a sub-second TTL would
+-- round to zero and two claims within the same second would compare as equal.
+CREATE TABLE IF NOT EXISTS idempotency_record (
+    id            VARCHAR(64)  NOT NULL PRIMARY KEY,
+    state         VARCHAR(16)  NOT NULL,
+    fingerprint   VARCHAR(64)  NOT NULL,
+    status        INT,
+    payload_type  VARCHAR(512),
+    payload       LONGTEXT,
+    created_at    DATETIME(6)  NOT NULL,
+    expires_at    DATETIME(6)  NOT NULL,
+    -- Declared inline because MySQL has no CREATE INDEX IF NOT EXISTS; re-running this file must
+    -- stay harmless.
+    INDEX ix_idempotency_expires (expires_at)
+) ENGINE = InnoDB;

--- a/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStoreTest.java
+++ b/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStoreTest.java
@@ -69,7 +69,8 @@ class JdbcIdempotencyStoreTest {
     }
 
     private JdbcIdempotencyStore store() {
-        return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), "idempotency_record");
+        return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), "idempotency_record",
+                new PostgresDialect());
     }
 
     /**

--- a/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolverTest.java
+++ b/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolverTest.java
@@ -1,0 +1,51 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Product-name mapping. Cheap to test directly, and worth doing so: the consequence of getting it
+ * wrong is not an error but the wrong SQL dialect running successfully against the wrong engine.
+ */
+class SqlDialectResolverTest {
+
+    @Test
+    void postgresVariantsMapToThePostgresDialect() {
+        assertThat(SqlDialectResolver.forProductName("PostgreSQL").name()).isEqualTo("PostgreSQL");
+    }
+
+    @Test
+    void mySqlMapsToTheMySqlDialect() {
+        assertThat(SqlDialectResolver.forProductName("MySQL").name()).isEqualTo("MySQL");
+    }
+
+    /** MariaDB reports its own name but is compatible with everything the claim uses. */
+    @Test
+    void mariaDbIsTreatedAsMySql() {
+        assertThat(SqlDialectResolver.forProductName("MariaDB").name()).isEqualTo("MySQL");
+    }
+
+    @Test
+    void matchingIsCaseInsensitive() {
+        // JDBC drivers are inconsistent about casing, and this is a plain string comparison.
+        assertThat(SqlDialectResolver.forProductName("postgresql").name()).isEqualTo("PostgreSQL");
+        assertThat(SqlDialectResolver.forProductName("MYSQL").name()).isEqualTo("MySQL");
+    }
+
+    @Test
+    void anUnsupportedDatabaseFailsNamingItselfAndTheEscapeHatch() {
+        // Failing loudly beats guessing: the wrong dialect would run, not error.
+        assertThatThrownBy(() -> SqlDialectResolver.forProductName("H2"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("H2")
+                .hasMessageContaining("idempotency.jdbc.dialect");
+    }
+
+    @Test
+    void aNullProductNameIsReportedRatherThanThrowingNullPointer() {
+        assertThatThrownBy(() -> SqlDialectResolver.forProductName(null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
Third of the six items scoped for 0.3.0. Branches from `main`, independent of #4 and #5.

## The seam is an algorithm, not a template

Only four statements differ between engines, but one of them is the atomic claim — the entire correctness argument of this library. So `IdempotencySqlDialect` owns the claim as an *operation*, not as a SQL string to interpolate.

That wasn't the original design. It was forced by a failure worth describing, because the obvious approach looks right and is badly wrong.

## What went wrong first

The natural MySQL translation of `ON CONFLICT ... DO UPDATE ... WHERE expired` is `INSERT ... ON DUPLICATE KEY UPDATE` with the expiry guard pushed into each assignment, deciding the outcome from the affected-row count: 1 = inserted, 2 = reclaimed, 0 = live row untouched.

**It does not work.** Connector/J defaults to `useAffectedRows=false`, which sets `CLIENT_FOUND_ROWS` and makes the driver report *matched* rather than *changed* rows. An unchanged duplicate then reports **1** — indistinguishable from a fresh insert.

Every duplicate read as a successful claim and executed. The behavioural matrix went red with `201`s where it expected `409`s and replays: the library doing the exact opposite of its job, gated on a connection-string option the *application* owns rather than this code. Nothing about it would have surfaced as an error in production — just duplicate charges.

## What it does instead

MySQL claims in two conditional statements, neither of which depends on row-count semantics:

1. An `UPDATE ... WHERE id = ? AND expires_at < CURRENT_TIMESTAMP(6)` — a live row is excluded by the **predicate**, so it matches zero under either driver mode. When it does match, it always changes values, so matched and changed agree.
2. If nothing was reclaimed, an `INSERT` either succeeds or violates the primary key. `DuplicateKeyException` is an exception, not a count, so no driver setting can blur it.

Concurrency holds on InnoDB's row and unique-index locks: two callers racing an expired row — the first reclaims it and pushes `expires_at` forward, the second no longer matches the predicate, falls through, and collides on the key. Exactly one wins.

## A second bug, caught by existing tests

My first cut detected the dialect eagerly at bean creation. That opens a connection **during startup**, so an unreachable database became a startup failure — destroying the point of `idempotency.on-store-failure=proceed`. Six existing tests went red, including `JdbcStoreUnavailableBehaviorTest`, which exists for exactly that scenario.

`LazySqlDialect` resolves on first use, so an unreachable store stays a request-time condition the failure policy can act on. Its `name()` deliberately does not resolve — a log line is not a good enough reason to open a database connection.

## Verification

`MySqlIdempotencyBehaviorTest` extends `AbstractIdempotencyBehaviorTest`, so the **entire** matrix runs against a real MySQL 8.4 container — concurrency soak (32 threads × 50 iterations) included. That is deliberate over a few smoke tests: the dialects differ in claim semantics and expiry comparison, which the matrix exercises far harder than any syntax check.

Plus MySQL-specific cases for the two halves of the claim: an expired row must be reclaimed rather than conflict, and a **live** row must be left completely untouched by a competing claim — a guard-ordering mistake would wipe a stored payload while still reporting a conflict, which no status-code assertion would catch.

`./gradlew clean build` green across Postgres, MySQL and Redis.

## Notes

- `db/idempotency/mysql.sql` uses `DATETIME(6)`, not `TIMESTAMP` — the latter is capped at 2038 and converts through the session time zone, which would make expiry depend on the client's zone. The `(6)` is required: without it MySQL truncates to whole seconds and sub-second TTLs round to nothing.
- MariaDB maps to the MySQL dialect; Aurora reports the engine it emulates, so needs no special case. An unrecognised database fails loudly naming itself and the property that overrides detection.
- Postgres SQL is byte-for-byte what shipped in 0.1/0.2, just moved into `PostgresDialect`.

## Remaining for 0.3.0

Caffeine store, WebFlux, `mode: filter`.
