### PR TITLE
Add a Caffeine-backed store with real eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency-store-caffeine`: a single-instance store with real TTL eviction and a bounded size
+  (`idempotency.caffeine.maximum-size`). The built-in `store=memory` treats expired entries as
+  absent but never removes them, so it grows for the life of the process - fine for tests, a slow
+  leak for a service that stays up.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ a silent execution of the wrong payload.
 | `idempotency.problem-details` | `true` | Registers the built-in RFC 9457 exception advice |
 | `idempotency.max-payload-size` | `256KB` | Larger responses execute normally but aren't cached for replay |
 | `idempotency.release-on` | `five_xx,timeout` | Outcomes that release instead of complete the key. Note the underscore: Spring's relaxed binding needs `five_xx`, not `5xx` |
+| `idempotency.caffeine.maximum-size` | `10000` | Ceiling on entries held by the Caffeine store; LRU beyond it |
 | `idempotency.redis.key-prefix` | `idempotency:` | |
 | `idempotency.jdbc.table-name` | `idempotency_record` | |
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
@@ -254,6 +255,9 @@ Being loud about these is what makes a library trustworthy:
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
 - Postgres only for the JDBC store (MySQL is on the roadmap).
+- `store=memory` never evicts expired entries, so it grows for as long as the process lives. It is
+  meant for tests and local development. For a single instance that stays up, use `store=caffeine`,
+  which has the same semantics plus real TTL eviction and a size ceiling.
 - Servlet stack only (WebFlux is on the roadmap).
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -72,6 +72,7 @@ public class IdempotencyProperties {
 
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
+    private final Caffeine caffeine = new Caffeine();
 
     public boolean isEnabled() {
         return enabled;
@@ -193,6 +194,10 @@ public class IdempotencyProperties {
         this.releaseOn = releaseOn;
     }
 
+    public Caffeine getCaffeine() {
+        return caffeine;
+    }
+
     public Redis getRedis() {
         return redis;
     }
@@ -201,13 +206,32 @@ public class IdempotencyProperties {
         return jdbc;
     }
 
-    public enum StoreType { AUTO, REDIS, JDBC, MEMORY }
+    public enum StoreType { AUTO, REDIS, JDBC, CAFFEINE, MEMORY }
 
     public enum OnStoreFailure { PROCEED, FAIL }
 
     public enum OnMissingPrincipal { GLOBAL, SKIP, REJECT }
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
+
+    public static class Caffeine {
+
+        /**
+         * Ceiling on entries held. Eviction normally happens by TTL; this is the backstop for when
+         * new keys arrive faster than old ones expire, so memory stays bounded instead of tracking
+         * traffic. Least-recently-used entries go first, which for idempotency keys means the ones
+         * least likely to still be retried.
+         */
+        private long maximumSize = 10_000;
+
+        public long getMaximumSize() {
+            return maximumSize;
+        }
+
+        public void setMaximumSize(long maximumSize) {
+            this.maximumSize = maximumSize;
+        }
+    }
 
     public static class Redis {
 

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,113 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.caffeine.maximum-size",
+      "description": "Maximum entries the Caffeine store holds. Records normally leave by TTL; this is the backstop for when new keys arrive faster than old ones expire, so memory stays bounded. Least-recently-used entries are evicted first."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "caffeine",
+          "description": "Single-instance, non-durable, with real TTL eviction and a bounded size. Requires idempotency-store-caffeine."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
       ]
     }
   ]

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":idempotency-core"))
     compileOnly(project(":idempotency-store-redis"))
     compileOnly(project(":idempotency-store-jdbc"))
+    compileOnly(project(":idempotency-store-caffeine"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -17,6 +18,7 @@ dependencies {
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation(project(":idempotency-store-caffeine"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.internal.scope.GlobalScopeResolver;
 import io.github.benhendayoussef.idempotency.internal.scope.PrincipalScopeResolver;
 import io.github.benhendayoussef.idempotency.internal.scope.TenantScopeResolver;
+import io.github.benhendayoussef.idempotency.store.caffeine.internal.CaffeineIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencyRecordSweeper;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySweeperScheduler;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
@@ -232,6 +233,21 @@ public class IdempotencyAutoConfiguration {
                         + "idempotency.jdbc.join-transaction=false to keep the at-least-once default.");
             }
             return new JdbcTransactionRunner(manager);
+        }
+    }
+
+    // Guards on the store class too, not just the property: idempotency-store-caffeine is optional
+    // (compileOnly here), so a user who set store=caffeine without adding the dependency must fall
+    // through to the fallback autoconfiguration and get its actionable message, not a NoClassDefFound.
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(CaffeineIdempotencyStore.class)
+    @ConditionalOnProperty(prefix = "idempotency", name = "store", havingValue = "caffeine")
+    static class CaffeineStoreConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(IdempotencyStore.class)
+        IdempotencyStore caffeineIdempotencyStore(IdempotencyProperties props) {
+            return new CaffeineIdempotencyStore(props.getCaffeine().getMaximumSize());
         }
     }
 

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
+import io.github.benhendayoussef.idempotency.store.caffeine.internal.CaffeineIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.io.IOException;
@@ -77,6 +78,30 @@ class IdempotencyAutoConfigurationTest {
                 .run(ctx -> {
                     assertThat(ctx).hasSingleBean(IdempotencyStore.class);
                     assertThat(ctx.getBean(IdempotencyStore.class)).isInstanceOf(JdbcIdempotencyStore.class);
+                });
+    }
+
+    @Test
+    void picksCaffeineWhenExplicitlyConfigured() {
+        runner.withPropertyValues("idempotency.store=caffeine")
+                .run(ctx -> {
+                    assertThat(ctx).hasSingleBean(IdempotencyStore.class);
+                    assertThat(ctx.getBean(IdempotencyStore.class))
+                            .isInstanceOf(CaffeineIdempotencyStore.class);
+                });
+    }
+
+    @Test
+    void caffeineWithoutTheModuleOnTheClasspathFailsWithTheActionableStoreMessage() {
+        // The module is optional. Asking for it without adding the dependency must produce the
+        // FailureAnalyzer message that names the problem, not a NoClassDefFoundError from a bean
+        // method that should never have been evaluated.
+        runner.withPropertyValues("idempotency.store=caffeine")
+                .withClassLoader(new FilteredClassLoader(CaffeineIdempotencyStore.class))
+                .run(ctx -> {
+                    assertThat(ctx).hasFailed();
+                    assertThat(ctx.getStartupFailure())
+                            .hasMessageContaining("No IdempotencyStore is configured");
                 });
     }
 

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CaffeineIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CaffeineIdempotencyBehaviorTest.java
@@ -1,0 +1,19 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * The full behavioural matrix against the Caffeine store.
+ *
+ * <p>No container needed - the point of this store is that it runs in-process - but the matrix is
+ * still worth running in full rather than trusting the unit tests. The store's contract is defined
+ * by what the aspect does with it, and the semantics that matter most here (a claim being visible
+ * to a concurrent duplicate, expiry being observed on the boundary) are exercised far harder by the
+ * concurrency soak and the TTL cases than by direct calls.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = AbstractIdempotencyBehaviorTest.TestApp.class,
+        properties = {"idempotency.store=caffeine",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+class CaffeineIdempotencyBehaviorTest extends AbstractIdempotencyBehaviorTest {
+}

--- a/idempotency-store-caffeine/build.gradle.kts
+++ b/idempotency-store-caffeine/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("java-library")
+}
+
+description = "Caffeine-backed idempotency store: single-instance, with real eviction and a bounded footprint."
+
+dependencies {
+    api(project(":idempotency-core"))
+    api("com.github.ben-manes.caffeine:caffeine")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/idempotency-store-caffeine/src/main/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStore.java
+++ b/idempotency-store-caffeine/src/main/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStore.java
@@ -1,0 +1,140 @@
+package io.github.benhendayoussef.idempotency.store.caffeine.internal;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Single-instance store with real eviction.
+ *
+ * <p>The built-in {@code InMemoryIdempotencyStore} is correct but unbounded: expired entries are
+ * <em>treated</em> as absent and never actually removed, so a long-running service accumulates one
+ * dead entry per idempotency key it has ever seen. That is fine for tests, which is what it was
+ * written for, and a slow leak in anything that stays up. This store keeps the same semantics and
+ * adds the two things that make it safe to leave running: per-entry expiry, so records go away when
+ * their TTL passes, and a maximum size, so memory has a ceiling even if traffic outruns expiry.
+ *
+ * <p>Still single-instance and still non-durable - state lives in local heap, so two application
+ * instances do not share it and a restart forgets everything. For anything replicated, use Redis or
+ * JDBC.
+ *
+ * <p>Public only because Spring auto-configuration in another module constructs it;
+ * <strong>not part of the supported API</strong>.
+ */
+public class CaffeineIdempotencyStore implements IdempotencyStore {
+
+    /**
+     * The expiry deadline is carried on the entry rather than being a fixed cache-wide duration,
+     * because TTL is per-record here: {@code @Idempotent(ttl = ...)} lets it vary per endpoint, and
+     * {@code complete()} re-stamps it.
+     */
+    private record Entry(IdempotencyRecord record, Instant expiresAt) {
+    }
+
+    private final Cache<String, Entry> cache;
+
+    public CaffeineIdempotencyStore(long maximumSize) {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfter(new Expiry<String, Entry>() {
+                    @Override
+                    public long expireAfterCreate(String key, Entry value, long currentTime) {
+                        return nanosUntil(value.expiresAt());
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(String key, Entry value, long currentTime,
+                            long currentDuration) {
+                        // Not currentDuration: complete() replaces an IN_PROGRESS entry with the
+                        // finished record and a fresh TTL, so keeping the remaining lifetime of the
+                        // claim would expire the stored response early - exactly when a replay needs
+                        // it most.
+                        return nanosUntil(value.expiresAt());
+                    }
+
+                    @Override
+                    public long expireAfterRead(String key, Entry value, long currentTime,
+                            long currentDuration) {
+                        // Reading must not extend the life of a record. Idempotency windows are
+                        // absolute: a key is valid for its TTL from when it was claimed, however
+                        // often it is replayed in the meantime.
+                        return currentDuration;
+                    }
+                })
+                .build();
+    }
+
+    private static long nanosUntil(Instant deadline) {
+        long nanos = Duration.between(Instant.now(), deadline).toNanos();
+        // Caffeine rejects a negative duration; an already-expired entry becomes immediately
+        // evictable instead.
+        return Math.max(nanos, 0L);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Atomic via {@code asMap().compute()}, which Caffeine performs under the entry's lock - the
+     * same guarantee {@code ConcurrentHashMap} gives, and the reason two concurrent duplicates
+     * cannot both be told they acquired the key.
+     *
+     * <p>The expiry check is still made explicitly here rather than relying on eviction. Eviction is
+     * asynchronous: an entry past its TTL can still be present for a short window, and treating it
+     * as live would mean a caller conflicts with a record that should already be gone.
+     */
+    @Override
+    public ClaimResult claim(String key, String fingerprint, Duration ttl) {
+        Instant now = Instant.now();
+        var candidate = new Entry(IdempotencyRecord.inProgress(fingerprint, now), now.plus(ttl));
+
+        Entry[] winner = new Entry[1];
+        cache.asMap().compute(key, (k, existing) -> {
+            if (existing == null || existing.expiresAt().isBefore(now)) {
+                winner[0] = candidate;
+                return candidate;
+            }
+            winner[0] = existing;
+            return existing;
+        });
+
+        if (winner[0] == candidate) {
+            return new ClaimResult.Acquired();
+        }
+        return new ClaimResult.AlreadyHeld(winner[0].record());
+    }
+
+    @Override
+    public void complete(String key, IdempotencyRecord record, Duration ttl) {
+        cache.put(key, new Entry(record, Instant.now().plus(ttl)));
+    }
+
+    @Override
+    public void release(String key) {
+        cache.invalidate(key);
+    }
+
+    @Override
+    public Optional<IdempotencyRecord> find(String key) {
+        Entry entry = cache.getIfPresent(key);
+        if (entry == null || entry.expiresAt().isBefore(Instant.now())) {
+            return Optional.empty();
+        }
+        return Optional.of(entry.record());
+    }
+
+    /** Entries currently held, after any pending eviction work. Exposed for tests and diagnostics. */
+    public long estimatedSize() {
+        cache.cleanUp();
+        return cache.estimatedSize();
+    }
+
+    /** Package-private hook so tests can assert eviction without sleeping for a real TTL. */
+    void runPendingEviction() {
+        cache.cleanUp();
+    }
+}

--- a/idempotency-store-caffeine/src/test/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStoreTest.java
+++ b/idempotency-store-caffeine/src/test/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStoreTest.java
@@ -1,0 +1,149 @@
+package io.github.benhendayoussef.idempotency.store.caffeine.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The semantics have to match the other stores exactly - the aspect cannot tell them apart - so the
+ * interesting tests here are the two things this store adds over the built-in in-memory one:
+ * entries are actually evicted, and memory has a ceiling.
+ */
+class CaffeineIdempotencyStoreTest {
+
+    private final CaffeineIdempotencyStore store = new CaffeineIdempotencyStore(10_000);
+
+    @Test
+    void aFreshKeyIsAcquiredAndASecondClaimConflicts() {
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.AlreadyHeld.class);
+    }
+
+    @Test
+    void completeThenFindReturnsTheStoredRecord() {
+        store.claim("k", "fp", Duration.ofMinutes(5));
+        var record = new IdempotencyRecord(IdempotencyRecord.State.COMPLETED, "fp", 201,
+                "java.lang.String", "\"body\"", Instant.now());
+        store.complete("k", record, Duration.ofMinutes(5));
+
+        assertThat(store.find("k")).isPresent().get()
+                .extracting(IdempotencyRecord::payload).isEqualTo("\"body\"");
+    }
+
+    @Test
+    void releaseMakesTheKeyImmediatelyReclaimable() {
+        store.claim("k", "fp", Duration.ofMinutes(5));
+        store.release("k");
+
+        assertThat(store.find("k")).isEmpty();
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+    }
+
+    /**
+     * The reason this store exists. The built-in in-memory store treats an expired entry as absent
+     * but never removes it, so its map grows by one entry per key ever seen. Here the entry has to
+     * actually leave the cache.
+     */
+    @Test
+    void expiredEntriesAreEvictedRatherThanJustHidden() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            store.claim("short-" + i, "fp", Duration.ofMillis(100));
+        }
+        assertThat(store.estimatedSize()).isEqualTo(50);
+
+        // Well past the TTL, and deliberately so. Caffeine schedules variable expiry on a timer
+        // wheel whose finest bucket spans roughly a second, so eviction is not immediate at the
+        // moment a TTL passes - it happens on the next maintenance cycle after the wheel advances.
+        // A shorter wait here fails intermittently and would look like a bug in the store.
+        //
+        // That lag is exactly why claim() and find() still compare expiry themselves rather than
+        // trusting presence in the cache: an entry can outlive its TTL briefly, and must not be
+        // treated as live during that window.
+        Thread.sleep(2_500);
+
+        assertThat(store.estimatedSize())
+                .as("entries past their TTL must be reclaimed, not merely reported as absent")
+                .isZero();
+    }
+
+    @Test
+    void anExpiredKeyIsReclaimableByTheNextClaim() throws Exception {
+        store.claim("k", "fp", Duration.ofMillis(50));
+        Thread.sleep(200);
+
+        assertThat(store.find("k")).isEmpty();
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+    }
+
+    /**
+     * Reading must not extend a record's life. An idempotency window is absolute - a key is valid
+     * for its TTL from when it was claimed - so a heavily replayed key must still expire on time.
+     * Caffeine's default read policy would renew it, which is why the expiry explicitly returns the
+     * remaining duration on read.
+     */
+    @Test
+    void repeatedReadsDoNotExtendTheTtl() throws Exception {
+        store.claim("k", "fp", Duration.ofMillis(300));
+        for (int i = 0; i < 20; i++) {
+            store.find("k");
+            Thread.sleep(20);
+        }
+        assertThat(store.find("k"))
+                .as("the key was read constantly but its window still ended on schedule")
+                .isEmpty();
+    }
+
+    @Test
+    void memoryIsBoundedWhenNewKeysOutrunExpiry() {
+        var bounded = new CaffeineIdempotencyStore(100);
+        for (int i = 0; i < 5_000; i++) {
+            bounded.claim("k-" + i, "fp", Duration.ofHours(1));
+        }
+        assertThat(bounded.estimatedSize())
+                .as("the ceiling is what keeps a long-running single instance from growing without limit")
+                .isLessThanOrEqualTo(100);
+    }
+
+    /** Two duplicates racing the same fresh key: exactly one may be told it acquired it. */
+    @Test
+    void concurrentClaimsOnTheSameKeyProduceExactlyOneWinner() throws Exception {
+        int threads = 32;
+        var go = new CountDownLatch(1);
+        var acquired = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new java.util.ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    go.await();
+                    if (store.claim("race", "fp", Duration.ofMinutes(5)) instanceof ClaimResult.Acquired) {
+                        acquired.incrementAndGet();
+                    }
+                    return null;
+                }));
+            }
+            go.countDown();
+            for (Future<?> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+        assertThat(acquired.get()).isEqualTo(1);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "idempotency-core",
     "idempotency-store-redis",
     "idempotency-store-jdbc",
+    "idempotency-store-caffeine",
     "idempotency-spring-boot-starter",
     "samples:sample-orders-api",
 )


### PR DESCRIPTION
Fourth of the six items scoped for 0.3.0.

## What it's actually for

`InMemoryIdempotencyStore` is correct but **unbounded**. An expired entry is *treated* as absent and never removed, so the map accumulates one dead entry per idempotency key the process has ever seen. That's fine for the tests it was written for, and a slow leak in anything that stays up.

This store has the same semantics plus the two things that make it safe to leave running: per-entry TTL eviction, and a maximum size (`idempotency.caffeine.maximum-size`, default 10 000) so memory has a ceiling even when new keys arrive faster than old ones expire.

Still single-instance and non-durable — heap state, not shared between instances, forgotten on restart. Redis or JDBC for anything replicated.

## Three details the expiry policy had to get right

- **TTL is per record, not cache-wide.** `@Idempotent(ttl = ...)` varies per endpoint, so the deadline rides on the entry.
- **`expireAfterUpdate` re-derives from the new entry** rather than keeping the remaining duration. `complete()` replaces an `IN_PROGRESS` claim with the finished record and a fresh TTL; keeping the claim's remaining lifetime would expire the stored response early — exactly when a replay needs it.
- **`expireAfterRead` returns the remaining duration unchanged.** An idempotency window is absolute: a key is valid for its TTL from when it was claimed, however often it's replayed. Renewing on read would keep a hot key alive indefinitely.

## One thing worth knowing about Caffeine

`claim()` and `find()` still compare expiry themselves rather than trusting absence from the cache. Caffeine schedules variable expiry on a **timer wheel whose finest bucket spans roughly a second**, so an entry can briefly outlive its TTL — and must not be treated as live in that window.

This bit me writing the tests: the eviction test failed at a 250 ms wait and passes at 2.5 s. It now waits well past the TTL and explains why, because a shorter wait fails intermittently and looks like a bug in the store rather than a property of the cache.

## Tests

Unit tests for the store, plus `CaffeineIdempotencyBehaviorTest` running the **full** inherited matrix — concurrency soak included. No container needed; running in-process is the point. Specifically covered: eviction actually reclaims, a heavily read key still expires on schedule, memory stays bounded when 5 000 keys hit a 100-entry ceiling, and 32 concurrent claims on one key produce exactly one winner.

Also a wiring test that `store=caffeine` without the optional module on the classpath produces the actionable "No IdempotencyStore is configured" message rather than a `NoClassDefFoundError`.

`./gradlew clean build` green.

## Remaining for 0.3.0

WebFlux and `mode: filter` — the two large ones. Starting WebFlux next.
