### PR TITLE
Add WebFlux support for Mono-returning handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency-webflux`: `@Idempotent` on reactive handlers returning `Mono`. The WAIT policy holds
+  no thread on this stack. Limitations, all documented: `Mono` only, blocking stores scheduled onto
+  `boundedElastic`, and `idempotency.scope=global` only - a non-global scope fails startup rather
+  than silently sharing keys across users.
+
+### Fixed
+
+- `IdempotencyAutoConfiguration` was gated entirely on a servlet web application, so everything in
+  it - store selection, the payload mapper, fingerprinting, metrics - was unavailable to any
+  non-servlet stack. Only the servlet aspect needed that condition.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Being loud about these is what makes a library trustworthy:
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
 - Postgres only for the JDBC store (MySQL is on the roadmap).
-- Servlet stack only (WebFlux is on the roadmap).
+- WebFlux support covers `Mono` only, with a blocking store on `boundedElastic` and `scope=global`. See the WebFlux section.
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.
 - `idempotency.scope` defaults to `global` (no Spring Security needed) precisely so the Quickstart
@@ -304,6 +304,44 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## WebFlux
+
+Add `idempotency-webflux` and `@Idempotent` works on reactive handlers that return `Mono`:
+
+```kotlin
+dependencies {
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.3.0")
+    implementation("io.github.benhendayoussef:idempotency-webflux:0.3.0")
+    implementation("io.github.benhendayoussef:idempotency-store-redis:0.3.0")
+}
+```
+
+```java
+@Idempotent
+@PostMapping("/orders")
+public Mono<ResponseEntity<OrderResponse>> placeOrder(@RequestBody OrderRequest request) { ... }
+```
+
+Nothing else to configure. The servlet and reactive aspects are mutually exclusive by construction,
+so an application gets exactly one.
+
+One thing is genuinely better here: `on-conflict=wait` occupies **no thread** while it waits, because
+the delay is a timer rather than a sleep. The thread-pool exhaustion documented under Limitations for
+the servlet stack does not apply.
+
+Three things to know before adopting it:
+
+- **Only `Mono` is advised.** A `Flux` is a stream, and this library replays a single captured
+  response - the same reason the servlet side does not support streaming. A `Flux`-returning handler
+  passes through untouched, with a WARN at startup rather than silent half-support.
+- **Stores are still blocking**, so store calls are scheduled onto `boundedElastic`. Correct, but an
+  idempotent endpoint costs two thread handoffs a plain one does not. A reactive store SPI (R2DBC,
+  reactive Redis) would remove that and is not in 0.3.0.
+- **`idempotency.scope` must be `global`.** `user` and `tenant` resolve the principal from
+  `SecurityContextHolder`, which is a ThreadLocal with no meaning on a reactive stack. Rather than
+  quietly falling back to global - which would share idempotency keys across users - startup fails
+  with an explanation.
 
 ## Extending
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
@@ -6,7 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 
 /** SHA-256 hex digest, used for both storage-key composition and argument fingerprinting. */
-final class Hashing {
+public final class Hashing {
 
     private Hashing() {
     }

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":idempotency-core"))
     compileOnly(project(":idempotency-store-redis"))
     compileOnly(project(":idempotency-store-jdbc"))
+    compileOnly(project(":idempotency-webflux"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -17,6 +18,8 @@ dependencies {
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation(project(":idempotency-webflux"))
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -61,7 +61,11 @@ import org.springframework.transaction.PlatformTransactionManager;
         "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
 })
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
-@ConditionalOnWebApplication(type = Type.SERVLET)
+// Any web application, not just servlet. Everything in this class except the aspect itself - store
+// selection, the payload mapper, fingerprinting, metrics, scope resolvers - is stack-agnostic, and
+// gating the whole class on SERVLET left a WebFlux application with no store at all. Only the
+// servlet aspect is servlet-specific, so only it carries the narrower condition.
+@ConditionalOnWebApplication
 @EnableConfigurationProperties(IdempotencyProperties.class)
 public class IdempotencyAutoConfiguration {
 
@@ -139,6 +143,7 @@ public class IdempotencyAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnWebApplication(type = Type.SERVLET)
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyStoreFallbackAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyStoreFallbackAutoConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -16,7 +15,9 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration(after = IdempotencyAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
-@ConditionalOnWebApplication(type = Type.SERVLET)
+// Any web application: a WebFlux app with no usable store needs the same actionable startup
+// failure a servlet one gets, rather than a NoSuchBeanDefinitionException from the aspect.
+@ConditionalOnWebApplication
 public class IdempotencyStoreFallbackAutoConfiguration {
 
     @Bean

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyWebFluxAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyWebFluxAutoConfiguration.java
@@ -1,0 +1,64 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import io.github.benhendayoussef.idempotency.internal.ArgumentFingerprinter;
+import io.github.benhendayoussef.idempotency.webflux.internal.IdempotencyExchangeContextFilter;
+import io.github.benhendayoussef.idempotency.webflux.internal.ReactiveIdempotencyAspect;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configures {@code @Idempotent} for WebFlux applications.
+ *
+ * <p>Mutually exclusive with {@link IdempotencyAutoConfiguration} by construction: that one is
+ * {@code @ConditionalOnWebApplication(SERVLET)} and this one is {@code REACTIVE}, so an application
+ * gets exactly one aspect and never both. That matters because the two would otherwise each claim
+ * the same key for the same request.
+ */
+@AutoConfiguration
+@ConditionalOnClass(ReactiveIdempotencyAspect.class)
+@ConditionalOnWebApplication(type = Type.REACTIVE)
+@ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
+@EnableConfigurationProperties(IdempotencyProperties.class)
+public class IdempotencyWebFluxAutoConfiguration {
+
+    /**
+     * Fails startup rather than silently ignoring a scope it cannot honour.
+     *
+     * <p>{@code USER} and {@code TENANT} resolve the principal from {@code SecurityContextHolder},
+     * a ThreadLocal with no meaning on a reactive stack - the reactive equivalent lives in the
+     * Reactor context and needs a different resolver SPI. Until that exists, an application that
+     * configured per-user scoping and quietly got global scoping instead would be sharing
+     * idempotency keys across users, which is a security problem, not a missing feature.
+     */
+    @Bean
+    public ReactiveIdempotencyAspect reactiveIdempotencyAspect(IdempotencyStore store,
+            IdempotencyProperties props, ArgumentFingerprinter fingerprinter,
+            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics) {
+        if (props.getScope() != IdempotencyScope.GLOBAL) {
+            throw new IllegalStateException(
+                    "idempotency.scope=" + props.getScope().name().toLowerCase()
+                    + " is not supported on WebFlux yet - only GLOBAL is. USER and TENANT resolve the "
+                    + "principal from SecurityContextHolder, which has no meaning on a reactive stack. "
+                    + "Falling back to GLOBAL silently would share idempotency keys across users, so "
+                    + "this fails instead. Set idempotency.scope=global, or use the servlet stack.");
+        }
+        return new ReactiveIdempotencyAspect(store, props, fingerprinter, idempotencyPayloadObjectMapper, metrics);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IdempotencyExchangeContextFilter idempotencyExchangeContextFilter() {
+        return new IdempotencyExchangeContextFilter();
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration
+io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyWebFluxAutoConfiguration

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -289,7 +289,8 @@ class IdempotencyAutoConfigurationTest {
         }
         assertThat(lines).containsExactlyInAnyOrder(
                 "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration",
-                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration");
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration",
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyWebFluxAutoConfiguration");
     }
 
     @Test

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
@@ -1,0 +1,315 @@
+package io.github.benhendayoussef.idempotency.webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+/**
+ * WebFlux behaviour through a real reactive stack, driven with {@link WebTestClient}.
+ *
+ * <p>These mirror the servlet matrix cases that genuinely differ here: the request is read from the
+ * Reactor context rather than a ThreadLocal, the store runs off the event loop, and the outcome is
+ * only known when the returned {@code Mono} completes. Every one of them could pass on the servlet
+ * side and fail on this one.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = WebFluxIdempotencyBehaviorTest.ReactiveApp.class,
+        properties = {"idempotency.store=memory", "idempotency.wait-timeout=3s",
+                // spring-boot-starter-web is on this module's test classpath for the servlet tests,
+                // and Boot prefers SERVLET whenever both stacks are present - so the web type has to
+                // be forced, or this would silently exercise the servlet aspect instead.
+                "spring.main.web-application-type=reactive",
+                // Likewise spring-boot-starter-jdbc: without this Boot tries to build a DataSource
+                // that this test never configures.
+                "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
+class WebFluxIdempotencyBehaviorTest {
+
+    @Autowired
+    private ReactiveController controller;
+
+    @Autowired
+    private ApplicationContext context;
+
+    private WebTestClient client;
+
+    @BeforeEach
+    void setUp() {
+        controller.reset();
+        client = WebTestClient.bindToApplicationContext(context).build()
+                .mutate().responseTimeout(Duration.ofSeconds(20)).build();
+    }
+
+    private WebTestClient.RequestHeadersSpec<?> post(String path, String key, String body) {
+        return client.post().uri(path)
+                .header("Idempotency-Key", key)
+                .header("Content-Type", "application/json")
+                .bodyValue(body);
+    }
+
+    @Test
+    void firstCallExecutesAndTheDuplicateReplaysWithoutReExecuting() {
+        String key = "wf-" + System.nanoTime();
+
+        post("/r/echo", key, "{\"a\":1}").exchange()
+                .expectStatus().isCreated()
+                .expectBody().jsonPath("$.a").isEqualTo(1);
+
+        post("/r/echo", key, "{\"a\":1}").exchange()
+                .expectStatus().isCreated()
+                .expectBody().jsonPath("$.a").isEqualTo(1);
+
+        assertThat(controller.echoCount()).as("the duplicate must be replayed, not re-executed").isEqualTo(1);
+    }
+
+    /**
+     * The case the operator chain has to lift explicitly. An empty {@code Mono} is a real response,
+     * and without turning that emptiness into a value the completion step never runs - leaving the
+     * key IN_PROGRESS until its TTL, so every later duplicate blocks or conflicts against a request
+     * that actually succeeded.
+     */
+    @Test
+    void aHandlerReturningAnEmptyMonoStillCompletesTheKey() {
+        String key = "wf-empty-" + System.nanoTime();
+
+        post("/r/empty", key, "{}").exchange().expectStatus().isOk();
+        post("/r/empty", key, "{}").exchange().expectStatus().isOk();
+
+        assertThat(controller.emptyCount())
+                .as("an empty response must be recorded as completed so the duplicate replays")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void sameKeyWithADifferentBodyIsRejectedRatherThanReplayed() {
+        String key = "wf-fp-" + System.nanoTime();
+
+        post("/r/echo", key, "{\"a\":1}").exchange().expectStatus().isCreated();
+        post("/r/echo", key, "{\"a\":999}").exchange()
+                // 422 by value: the enum constant was renamed to UNPROCESSABLE_CONTENT, and
+                // asserting on the constant makes this fail on one Spring version and pass on another.
+                .expectStatus().isEqualTo(422);
+
+        assertThat(controller.echoCount()).isEqualTo(1);
+    }
+
+    @Test
+    void a5xxReleasesTheKeySoARetryCanSucceed() {
+        String key = "wf-5xx-" + System.nanoTime();
+        controller.failNext();
+
+        post("/r/flaky", key, "{}").exchange().expectStatus().is5xxServerError();
+        post("/r/flaky", key, "{}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.flakyCount())
+                .as("a transient failure releases the key, so the retry re-executes")
+                .isEqualTo(2);
+    }
+
+    @Test
+    void a4xxIsKeptAndReplayedToTheRetry() {
+        String key = "wf-4xx-" + System.nanoTime();
+
+        post("/r/bad", key, "{}").exchange().expectStatus().isBadRequest();
+        // The replay must be a 400 too. It arrives as an ErrorResponse rather than a returned
+        // ResponseEntity - see ReactiveIdempotencyAspect.replay - which is what keeps the status
+        // intact regardless of what the handler declares it returns.
+        post("/r/bad", key, "{}").exchange().expectStatus().isBadRequest();
+
+        assertThat(controller.badCount())
+                .as("a deterministic client error is replayed, not re-executed")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void aRequestWithNoKeyPassesThroughAndExecutesEveryTime() {
+        client.post().uri("/r/echo").header("Content-Type", "application/json")
+                .bodyValue("{\"a\":1}").exchange().expectStatus().isCreated();
+        client.post().uri("/r/echo").header("Content-Type", "application/json")
+                .bodyValue("{\"a\":1}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.echoCount()).isEqualTo(2);
+    }
+
+    @Test
+    void aSlowHandlerStillReplaysItsResponseToALaterDuplicate() {
+        String key = "wf-slow-" + System.nanoTime();
+
+        post("/r/slow", key, "{}").exchange().expectStatus().isCreated();
+        post("/r/slow", key, "{}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.slowCount()).isEqualTo(1);
+    }
+
+    /**
+     * Two duplicates genuinely in flight at once. The loser takes the WAIT path, which on this stack
+     * holds no thread while it waits - the delay is a timer, not a sleep. That removes the
+     * thread-pool exhaustion the servlet side documents as a limitation.
+     */
+    @Test
+    void twoConcurrentDuplicatesExecuteOnceAndBothGetTheSameResponse() {
+        String key = "wf-race-" + System.nanoTime();
+
+        Mono<Integer> a = sendForStatus("/r/slow", key);
+        Mono<Integer> b = sendForStatus("/r/slow", key);
+
+        var statuses = Mono.zip(a, b).block(Duration.ofSeconds(20));
+
+        assertThat(statuses).isNotNull();
+        assertThat(statuses.getT1()).isEqualTo(201);
+        assertThat(statuses.getT2()).isEqualTo(201);
+        assertThat(controller.slowCount())
+                .as("exactly one of the two concurrent duplicates may execute the handler")
+                .isEqualTo(1);
+    }
+
+    private Mono<Integer> sendForStatus(String path, String key) {
+        return Mono.fromCallable(() -> post(path, key, "{}").exchange()
+                        .returnResult(String.class).getStatus().value())
+                .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic());
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class ReactiveApp {
+        @Bean
+        ReactiveController reactiveController() {
+            return new ReactiveController();
+        }
+
+        /**
+         * spring-boot-starter-security is on this module's test classpath for the servlet security
+         * test, and WebFlux's default chain applies CSRF to every POST - which returned 403 for
+         * every request here, with nothing to do with idempotency. Declared explicitly rather than
+         * excluded by autoconfiguration class name, because that name differs between Boot
+         * generations and this suite has to run on both.
+         */
+        @Bean
+        SecurityWebFilterChain permitEverything(ServerHttpSecurity http) {
+            return http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+                    .authorizeExchange(ex -> ex.anyExchange().permitAll())
+                    .build();
+        }
+    }
+
+    @RestController
+    static class ReactiveController {
+        private final AtomicInteger echo = new AtomicInteger();
+        private final AtomicInteger empty = new AtomicInteger();
+        private final AtomicInteger flaky = new AtomicInteger();
+        private final AtomicInteger bad = new AtomicInteger();
+        private final AtomicInteger slow = new AtomicInteger();
+        private final AtomicBoolean failNext = new AtomicBoolean();
+
+        void reset() {
+            echo.set(0);
+            empty.set(0);
+            flaky.set(0);
+            bad.set(0);
+            slow.set(0);
+            failNext.set(false);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        int echoCount() {
+            return echo.get();
+        }
+
+        int emptyCount() {
+            return empty.get();
+        }
+
+        int flakyCount() {
+            return flaky.get();
+        }
+
+        int badCount() {
+            return bad.get();
+        }
+
+        int slowCount() {
+            return slow.get();
+        }
+
+        @Idempotent
+        @PostMapping("/r/echo")
+        Mono<ResponseEntity<Map<String, Object>>> echo(@RequestBody Map<String, Object> body) {
+            echo.incrementAndGet();
+            return Mono.just(ResponseEntity.status(HttpStatus.CREATED).body(body));
+        }
+
+        @Idempotent
+        @PostMapping("/r/empty")
+        Mono<Void> emptyResponse(@RequestBody Map<String, Object> body) {
+            empty.incrementAndGet();
+            return Mono.empty();
+        }
+
+        @Idempotent
+        @PostMapping("/r/flaky")
+        Mono<ResponseEntity<Map<String, Object>>> flaky(@RequestBody Map<String, Object> body) {
+            flaky.incrementAndGet();
+            if (failNext.compareAndSet(true, false)) {
+                return Mono.error(new InfrastructureException());
+            }
+            return Mono.just(ResponseEntity.status(HttpStatus.CREATED).body(Map.of("ok", true)));
+        }
+
+        @Idempotent
+        @PostMapping("/r/bad")
+        Mono<ResponseEntity<Map<String, Object>>> bad(@RequestBody Map<String, Object> body) {
+            bad.incrementAndGet();
+            return Mono.error(new ClientException());
+        }
+
+        @Idempotent
+        @PostMapping("/r/slow")
+        Mono<ResponseEntity<Map<String, Object>>> slow(@RequestBody Map<String, Object> body) {
+            slow.incrementAndGet();
+            return Mono.delay(Duration.ofMillis(400))
+                    .map(t -> ResponseEntity.status(HttpStatus.CREATED).body(Map.of("ok", true)));
+        }
+
+        // ResponseStatusException rather than a plain exception annotated @ResponseStatus.
+        // WebFlux maps this shape unconditionally, whereas annotation-driven status resolution
+        // depends on which error handler the application has configured - and when it is not in
+        // play everything becomes a default 500, which made the 5xx case below pass for entirely
+        // the wrong reason. These tests are about the failure policy (5xx releases, 4xx is kept
+        // and replayed), so the status has to be unambiguous.
+        static class InfrastructureException extends ResponseStatusException {
+            InfrastructureException() {
+                super(HttpStatus.INTERNAL_SERVER_ERROR, "boom");
+            }
+        }
+
+        static class ClientException extends ResponseStatusException {
+            ClientException() {
+                super(HttpStatus.BAD_REQUEST, "nope");
+            }
+        }
+    }
+}

--- a/idempotency-webflux/build.gradle.kts
+++ b/idempotency-webflux/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("java-library")
+}
+
+description = "WebFlux support for @Idempotent: a reactive aspect for Mono-returning handlers."
+
+dependencies {
+    api(project(":idempotency-core"))
+    api("org.springframework:spring-webflux")
+    api("io.projectreactor:reactor-core")
+    implementation("org.springframework:spring-web")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("org.aspectj:aspectjweaver")
+    implementation("org.slf4j:slf4j-api")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
+    testImplementation("io.projectreactor:reactor-test")
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/IdempotencyExchangeContextFilter.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/IdempotencyExchangeContextFilter.java
@@ -1,0 +1,44 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import org.springframework.core.Ordered;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Puts the {@link ServerWebExchange} into the Reactor context so the aspect can reach it.
+ *
+ * <p>The servlet aspect reads the current request from {@code RequestContextHolder}, a ThreadLocal.
+ * That has no reactive equivalent: a single request is handled across whatever threads the operators
+ * happen to run on, so there is no "current request" for a thread to hold. The Reactor context is
+ * the reactive counterpart - it travels with the subscription rather than with a thread - and the
+ * only way to get the exchange into it is a filter that writes it there.
+ *
+ * <p>The context propagates <em>upstream</em>, from subscriber toward publisher, which is why
+ * {@code contextWrite} is applied to the result of {@code chain.filter(...)} rather than before it:
+ * everything downstream of this filter, the handler and the aspect included, then sees the value.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public class IdempotencyExchangeContextFilter implements WebFilter, Ordered {
+
+    /** Context key. Class-name based so it cannot collide with an application's own entries. */
+    public static final String CONTEXT_KEY = IdempotencyExchangeContextFilter.class.getName();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange).contextWrite(ctx -> ctx.put(CONTEXT_KEY, exchange));
+    }
+
+    /**
+     * Runs before anything that might need the exchange. Ordered explicitly rather than left to
+     * registration order, because a filter that writes the context after the handler has already
+     * been invoked would be silently useless - the aspect would just never find the exchange.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 100;
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveIdempotencyAspect.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveIdempotencyAspect.java
@@ -1,0 +1,439 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
+import io.github.benhendayoussef.idempotency.api.FingerprintMismatchException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyConflictException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyKeyRequiredException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStoreUnavailableException;
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import io.github.benhendayoussef.idempotency.internal.ArgumentFingerprinter;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * The WebFlux counterpart to {@code IdempotencyAspect}, for handlers that return {@code Mono}.
+ *
+ * <p>It is a separate aspect rather than a branch inside the servlet one because almost nothing
+ * carries over. The servlet aspect reads the request from a ThreadLocal, calls the store inline, and
+ * decides the outcome before returning; here the request lives in the Reactor context, every store
+ * call has to leave the event loop, and the outcome is only known when the returned {@code Mono}
+ * completes - so the whole claim/execute/complete sequence is assembled as an operator chain instead
+ * of executed as statements.
+ *
+ * <h2>Two limitations worth stating plainly</h2>
+ *
+ * <p><strong>The store is blocking, so store calls run on {@code boundedElastic}.</strong> Every
+ * {@code IdempotencyStore} implementation is synchronous JDBC or Lettuce-blocking, and calling one
+ * on an event-loop thread is the classic way to stall a reactive application. Scheduling them onto
+ * the elastic pool is correct but it is not free: an idempotent endpoint costs two thread handoffs
+ * that a plain one does not. A genuinely reactive store SPI (R2DBC, reactive Redis) would remove
+ * that, and is deliberately not in this change.
+ *
+ * <p><strong>Only {@code Mono} is advised.</strong> A {@code Flux} return is a stream, and this
+ * library captures a single response value to replay later - the same reason the servlet side does
+ * not support streaming responses. A {@code Flux}-returning handler passes through untouched rather
+ * than being half-supported.
+ */
+@Aspect
+public class ReactiveIdempotencyAspect implements Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(ReactiveIdempotencyAspect.class);
+
+    /** Marks a stored record as an error response rather than a handler return value. */
+    private static final String ERROR_PAYLOAD_TYPE = "!error";
+
+    private final IdempotencyStore store;
+    private final IdempotencyProperties props;
+    private final ArgumentFingerprinter fingerprinter;
+    private final ObjectMapper payloadMapper;
+    private final IdempotencyMetrics metrics;
+
+    public ReactiveIdempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
+            ArgumentFingerprinter fingerprinter, ObjectMapper payloadMapper, IdempotencyMetrics metrics) {
+        this.store = store;
+        this.props = props;
+        this.fingerprinter = fingerprinter;
+        this.payloadMapper = payloadMapper;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public int getOrder() {
+        return props.getAspectOrder();
+    }
+
+    @Around("@annotation(io.github.benhendayoussef.idempotency.api.Idempotent)")
+    public Object around(ProceedingJoinPoint pjp) throws Throwable {
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+
+        if (!Mono.class.isAssignableFrom(method.getReturnType())) {
+            // Flux, or a plain blocking return in a reactive application. Passing it through is the
+            // honest outcome: advising it would either block the event loop or capture only the
+            // first element of a stream, and both are worse than doing nothing.
+            log.warn("@Idempotent on {}.{} returns {} - only Mono is supported on WebFlux, so the "
+                            + "annotation has no effect here",
+                    method.getDeclaringClass().getSimpleName(), method.getName(),
+                    method.getReturnType().getSimpleName());
+            return pjp.proceed();
+        }
+
+        Idempotent ann = method.getAnnotation(Idempotent.class);
+
+        // deferContextual, not defer: the exchange is only reachable once someone subscribes, and
+        // nothing before that point knows which request this is.
+        return Mono.deferContextual(ctx -> {
+            ServerWebExchange exchange = ctx.hasKey(IdempotencyExchangeContextFilter.CONTEXT_KEY)
+                    ? ctx.get(IdempotencyExchangeContextFilter.CONTEXT_KEY)
+                    : null;
+            if (exchange == null) {
+                // The filter is auto-registered, so this means someone replaced the filter chain.
+                // Failing loudly beats silently executing every duplicate.
+                return Mono.error(new IllegalStateException(
+                        "No ServerWebExchange in the Reactor context. IdempotencyExchangeContextFilter "
+                        + "must be registered as a WebFilter for @Idempotent to work on WebFlux."));
+            }
+            return applyIdempotency(pjp, method, ann, exchange);
+        });
+    }
+
+    private Mono<Object> applyIdempotency(ProceedingJoinPoint pjp, Method method, Idempotent ann,
+            ServerWebExchange exchange) {
+        String headerName = ann.keyHeader().isBlank() ? props.getHeaderName() : ann.keyHeader();
+        String clientKey = exchange.getRequest().getHeaders().getFirst(headerName);
+
+        if (clientKey == null || clientKey.isBlank()) {
+            metrics.missingKey();
+            if (props.isRequireKey()) {
+                return Mono.error(new IdempotencyKeyRequiredException());
+            }
+            return proceedAsMono(pjp);
+        }
+
+        String storeKey = ReactiveKeyComposer.compose(clientKey, "", exchange);
+        String fingerprint = ann.fingerprintArgs() ? fingerprinter.fingerprint(method, pjp.getArgs()) : "";
+        Duration ttl = ann.ttl().isBlank() ? props.getDefaultTtl() : Duration.parse("PT" + ann.ttl());
+
+        // The claim result is carried in an Optional rather than signalled by an empty Mono. An
+        // earlier version used switchIfEmpty to mean "the store failed, proceed unprotected", which
+        // was wrong in a way only a handler returning Mono.empty() reveals: a legitimately empty
+        // response also completes empty, so the handler ran a second time - and a replay of that
+        // stored empty response ran it a third. Emptiness is a valid outcome here, so it cannot
+        // double as a control signal.
+        return blocking(() -> store.claim(storeKey, fingerprint, ttl))
+                .map(java.util.Optional::of)
+                .onErrorResume(RuntimeException.class, this::onClaimFailure)
+                .flatMap(claim -> claim
+                        .map(c -> c instanceof ClaimResult.AlreadyHeld held
+                                ? handleExisting(pjp, method, held.record(), storeKey, fingerprint, ttl)
+                                : execute(pjp, method, storeKey, fingerprint, ttl))
+                        // Empty Optional: the store was unreachable and the policy said PROCEED.
+                        .orElseGet(() -> proceedAsMono(pjp)));
+    }
+
+    private Mono<java.util.Optional<ClaimResult>> onClaimFailure(RuntimeException e) {
+        metrics.storeFailure();
+        if (props.getOnStoreFailure() == IdempotencyProperties.OnStoreFailure.FAIL) {
+            return Mono.error(new IdempotencyStoreUnavailableException(e));
+        }
+        log.warn("Idempotency store unavailable; executing unprotected per idempotency.on-store-failure", e);
+        return Mono.just(java.util.Optional.empty());
+    }
+
+    // --- Execute path -------------------------------------------------------------------------
+
+    private Mono<Object> execute(ProceedingJoinPoint pjp, Method method, String storeKey,
+            String fingerprint, Duration ttl) {
+        // singleOptional, not a bare flatMap: a handler returning Mono.empty() is a legitimate
+        // response with no body, and it must still be recorded as completed. Without lifting the
+        // emptiness into a value the completion step would never run for those handlers and the key
+        // would sit IN_PROGRESS until its TTL - every later duplicate blocking or 409-ing against a
+        // request that actually succeeded.
+        return proceedAsMono(pjp)
+                .singleOptional()
+                .flatMap(result -> completeThen(result.orElse(null), method, storeKey, fingerprint, ttl)
+                        .then(Mono.justOrEmpty(result)))
+                .onErrorResume(t -> settleFailure(storeKey, fingerprint, ttl, t).then(Mono.error(t)));
+    }
+
+    private Mono<Void> completeThen(Object result, Method method, String storeKey, String fingerprint,
+            Duration ttl) {
+        IdempotencyRecord record = toRecord(result, fingerprint, method);
+        if (exceedsMaxPayload(record)) {
+            return blocking(() -> {
+                store.release(storeKey);
+                log.warn("Idempotent response for key {} exceeds idempotency.max-payload-size; not cached",
+                        storeKey);
+                metrics.executed();
+                return true;
+            }).then();
+        }
+        return blocking(() -> {
+            store.complete(storeKey, record, ttl);
+            metrics.executed();
+            return true;
+        }).then();
+    }
+
+    private Mono<Void> settleFailure(String storeKey, String fingerprint, Duration ttl, Throwable t) {
+        if (shouldRelease(t)) {
+            return blocking(() -> {
+                store.release(storeKey);
+                metrics.released();
+                return null;
+            }).then();
+        }
+        return blocking(() -> {
+            store.complete(storeKey, toErrorRecord(t, fingerprint), ttl);
+            return null;
+        }).then();
+    }
+
+    // --- Replay / conflict path ---------------------------------------------------------------
+
+    private Mono<Object> handleExisting(ProceedingJoinPoint pjp, Method method, IdempotencyRecord record,
+            String storeKey, String fingerprint, Duration ttl) {
+        if (!fingerprint.isEmpty() && !fingerprint.equals(record.fingerprint())) {
+            metrics.fingerprintMismatch();
+            return Mono.error(new FingerprintMismatchException());
+        }
+        if (record.state() == State.COMPLETED) {
+            metrics.replayed();
+            return replay(record, method);
+        }
+        if (props.getOnConflict() == ConflictPolicy.FAIL_FAST) {
+            metrics.conflict();
+            return Mono.error(new IdempotencyConflictException());
+        }
+        return waitForCompletion(method, storeKey);
+    }
+
+    /**
+     * WAIT policy. Polls the store until the in-flight request finishes or the timeout expires.
+     *
+     * <p>Unlike the servlet implementation this occupies no thread while waiting - the delay is a
+     * timer, not a sleep - which removes the thread-pool exhaustion the servlet side documents as a
+     * limitation. That is the one place the reactive version is meaningfully better.
+     */
+    private Mono<Object> waitForCompletion(Method method, String storeKey) {
+        Duration timeout = props.getWaitTimeout();
+        Duration interval = Duration.ofMillis(50);
+        Instant deadline = Instant.now().plus(timeout);
+
+        return Mono.defer(() -> blocking(() -> store.find(storeKey)))
+                .flatMap(found -> found
+                        .filter(r -> r.state() == State.COMPLETED)
+                        .map(r -> {
+                            metrics.replayedAfterWait();
+                            return replay(r, method);
+                        })
+                        .orElseGet(Mono::empty))
+                .repeatWhenEmpty(flux -> flux
+                        .delayElements(interval)
+                        .takeWhile(i -> Instant.now().isBefore(deadline)))
+                .onErrorResume(IllegalStateException.class, e -> {
+                    // repeatWhenEmpty signals exhaustion this way rather than completing empty.
+                    metrics.waitTimeout();
+                    return Mono.error(new IdempotencyConflictException());
+                });
+    }
+
+    private Mono<Object> replay(IdempotencyRecord record, Method method) {
+        Type payloadType = monoPayloadType(method);
+
+        if (ERROR_PAYLOAD_TYPE.equals(record.payloadType())) {
+            // Always re-thrown, never returned as a value - including when the handler declares
+            // ResponseEntity. WebFlux picks the message writer from the *declared* generic type, so
+            // handing a ProblemDetail body to a method declared Mono<ResponseEntity<Map<..>>> fails
+            // conversion and renders 500: the replayed 4xx would arrive as a server error, which is
+            // the one outcome a retry must never see. Surfacing it as an ErrorResponse makes the
+            // framework render the stored status and body directly, whatever the declared type is.
+            ProblemDetail body = readProblemDetail(record.payload(), record.status());
+            return Mono.error(new ReplayedErrorResponseException(record.status(), body));
+        }
+
+        Object body = record.payload() == null ? null : readJson(record.payload(), innerType(payloadType));
+        if (isResponseEntity(payloadType)) {
+            return Mono.just(ResponseEntity.status(record.status()).body(body));
+        }
+        return body == null ? Mono.empty() : Mono.just(body);
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    /**
+     * Runs a blocking store call off the event loop.
+     *
+     * <p>{@code fromCallable} rather than {@code just}: the call must not happen at assembly time,
+     * only when subscribed. {@code boundedElastic} is the scheduler Reactor provides precisely for
+     * wrapping blocking I/O that cannot be made reactive.
+     */
+    private <T> Mono<T> blocking(java.util.concurrent.Callable<T> call) {
+        return Mono.fromCallable(call).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<Object> proceedAsMono(ProceedingJoinPoint pjp) {
+        try {
+            Object result = pjp.proceed();
+            return result == null ? Mono.empty() : (Mono<Object>) result;
+        } catch (Throwable t) {
+            return Mono.error(t);
+        }
+    }
+
+    /** The {@code T} in a declared {@code Mono<T>}. */
+    private static Type monoPayloadType(Method method) {
+        Type generic = method.getGenericReturnType();
+        if (generic instanceof ParameterizedType pt && pt.getActualTypeArguments().length == 1) {
+            return pt.getActualTypeArguments()[0];
+        }
+        return Object.class;
+    }
+
+    private static boolean isResponseEntity(Type type) {
+        if (type instanceof ParameterizedType pt) {
+            return pt.getRawType() == ResponseEntity.class;
+        }
+        return type == ResponseEntity.class;
+    }
+
+    /** For {@code Mono<ResponseEntity<T>>} the stored body is the {@code T}, not the entity. */
+    private static Type innerType(Type payloadType) {
+        if (isResponseEntity(payloadType) && payloadType instanceof ParameterizedType pt
+                && pt.getActualTypeArguments().length == 1) {
+            return pt.getActualTypeArguments()[0];
+        }
+        return payloadType;
+    }
+
+    private IdempotencyRecord toRecord(Object result, String fingerprint, Method method) {
+        int status = 200;
+        Object body = result;
+        if (result instanceof ResponseEntity<?> re) {
+            status = re.getStatusCode().value();
+            body = re.getBody();
+        }
+        return new IdempotencyRecord(State.COMPLETED, fingerprint, status,
+                monoPayloadType(method).getTypeName(), writeJson(body), Instant.now());
+    }
+
+    private IdempotencyRecord toErrorRecord(Throwable t, String fingerprint) {
+        int status = resolveStatus(t);
+        Object body = (t instanceof ErrorResponse er) ? er.getBody() : problemDetailFor(status, t.getMessage());
+        return new IdempotencyRecord(State.COMPLETED, fingerprint, status, ERROR_PAYLOAD_TYPE,
+                writeJson(body), Instant.now());
+    }
+
+    private static ProblemDetail problemDetailFor(int status, String message) {
+        ProblemDetail pd = ProblemDetail.forStatus(status);
+        if (message != null) {
+            pd.setDetail(message);
+        }
+        return pd;
+    }
+
+    private boolean shouldRelease(Throwable t) {
+        return resolveStatus(t) >= 500
+                && props.getReleaseOn().contains(IdempotencyProperties.ReleaseOn.FIVE_XX);
+    }
+
+    private static int resolveStatus(Throwable t) {
+        if (t instanceof ErrorResponse er) {
+            return er.getStatusCode().value();
+        }
+        var ann = org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation(
+                t.getClass(), org.springframework.web.bind.annotation.ResponseStatus.class);
+        return ann != null ? ann.code().value() : HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
+
+    private boolean exceedsMaxPayload(IdempotencyRecord record) {
+        return record.payload() != null
+                && record.payload().length() > props.getMaxPayloadSize().toBytes();
+    }
+
+    private String writeJson(Object body) {
+        if (body == null) {
+            return null;
+        }
+        try {
+            return payloadMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize idempotent response body", e);
+        }
+    }
+
+    /**
+     * Rebuilds the stored error body.
+     *
+     * <p>Read as a map and reassembled rather than deserialized straight into {@link ProblemDetail}:
+     * that type is built for writing, not reading, and Jackson cannot reliably reconstruct it -
+     * which turned every replayed 4xx into a 500 until this was changed. Going through a map also
+     * preserves any extension members the original carried.
+     */
+    private ProblemDetail readProblemDetail(String json, int status) {
+        ProblemDetail detail = ProblemDetail.forStatus(status);
+        if (json == null) {
+            return detail;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> map = payloadMapper.readValue(json, java.util.Map.class);
+            Object title = map.remove("title");
+            Object det = map.remove("detail");
+            Object instance = map.remove("instance");
+            Object type = map.remove("type");
+            map.remove("status");
+            if (title != null) {
+                detail.setTitle(String.valueOf(title));
+            }
+            if (det != null) {
+                detail.setDetail(String.valueOf(det));
+            }
+            if (instance != null) {
+                detail.setInstance(java.net.URI.create(String.valueOf(instance)));
+            }
+            if (type != null) {
+                detail.setType(java.net.URI.create(String.valueOf(type)));
+            }
+            map.forEach(detail::setProperty);
+            return detail;
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize stored idempotent error response", e);
+        }
+    }
+
+    private Object readJson(String json, Type type) {
+        try {
+            JavaType javaType = payloadMapper.getTypeFactory().constructType(type);
+            return payloadMapper.readValue(json, javaType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize stored idempotent response", e);
+        }
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveKeyComposer.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveKeyComposer.java
@@ -1,0 +1,33 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import io.github.benhendayoussef.idempotency.internal.Hashing;
+import java.util.Objects;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * The WebFlux counterpart to {@code IdempotencyKeyComposer}.
+ *
+ * <p>Produces byte-identical keys to the servlet version for the same request, deliberately: the two
+ * stacks can share a store - a service migrating from MVC to WebFlux one endpoint at a time has
+ * both running against the same Redis - and a key that changed shape mid-migration would silently
+ * stop deduplicating exactly when it mattered.
+ *
+ * <p>The route pattern, not the raw URI, is what goes into the hash. Otherwise {@code /orders/1} and
+ * {@code /orders/2} would be different routes to the deduplication logic even though they are the
+ * same endpoint, and a client reusing one key across them would not be protected.
+ */
+final class ReactiveKeyComposer {
+
+    private ReactiveKeyComposer() {
+    }
+
+    static String compose(String clientKey, String namespace, ServerWebExchange exchange) {
+        // BEST_MATCHING_PATTERN_ATTRIBUTE holds a PathPattern here rather than the String the
+        // servlet stack stores; toString() gives the same pattern text either way.
+        Object pattern = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        String route = Objects.toString(pattern, exchange.getRequest().getPath().value());
+        String method = exchange.getRequest().getMethod().name();
+        return Hashing.sha256Hex(namespace + '|' + method + '|' + route + '|' + clientKey);
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReplayedErrorResponseException.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReplayedErrorResponseException.java
@@ -1,0 +1,54 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Carries a replayed error response back out through the reactive pipeline.
+ *
+ * <p>The servlet aspect can write a stored error straight to the {@code HttpServletResponse} when the
+ * handler's declared return type cannot express an arbitrary status. There is no equivalent here -
+ * writing to the response mid-pipeline races the framework's own rendering - so the stored status and
+ * body are surfaced as an exception instead.
+ *
+ * <p>It extends {@link ResponseStatusException} specifically, rather than merely implementing
+ * {@code ErrorResponse}. WebFlux's status handling maps {@code ResponseStatusException}; a plain
+ * exception that only implements {@code ErrorResponse} falls through to the generic handler and
+ * renders <strong>500</strong>. That turns a replayed 400 into a server error - the one answer a
+ * retry must never get, and worse than not replaying at all, since the caller now sees a failure
+ * that never actually happened.
+ */
+final class ReplayedErrorResponseException extends ResponseStatusException {
+
+    private static final long serialVersionUID = 1L;
+
+    ReplayedErrorResponseException(int status, ProblemDetail stored) {
+        super(HttpStatusCode.valueOf(status), stored != null ? stored.getDetail() : null);
+        copyInto(getBody(), stored);
+    }
+
+    /**
+     * {@code getBody()} is final on the superclass, so the recorded body is copied onto the one this
+     * exception already owns rather than replacing it. The effect is the same and it is what matters
+     * here: a retry sees the title, detail and extension members the first caller saw, not a fresh
+     * ProblemDetail rebuilt from the status alone.
+     */
+    private static void copyInto(ProblemDetail target, ProblemDetail stored) {
+        if (stored == null) {
+            return;
+        }
+        if (stored.getTitle() != null) {
+            target.setTitle(stored.getTitle());
+        }
+        if (stored.getType() != null) {
+            target.setType(stored.getType());
+        }
+        if (stored.getInstance() != null) {
+            target.setInstance(stored.getInstance());
+        }
+        if (stored.getProperties() != null) {
+            stored.getProperties().forEach(target::setProperty);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "idempotency-core",
     "idempotency-store-redis",
     "idempotency-store-jdbc",
+    "idempotency-webflux",
     "idempotency-spring-boot-starter",
     "samples:sample-orders-api",
 )


### PR DESCRIPTION
Fifth of the six items scoped for 0.3.0. The large one.

## Why a separate aspect

Almost nothing carries over from the servlet aspect. The request lives in the Reactor context instead of a ThreadLocal, every store call has to leave the event loop, and the outcome is only known when the returned `Mono` completes — so claim/execute/complete is assembled as an operator chain rather than executed as statements.

`IdempotencyExchangeContextFilter` puts the `ServerWebExchange` into the Reactor context, since there is no "current request" for a thread to hold on this stack.

## A fix that was a prerequisite

`IdempotencyAutoConfiguration` was gated entirely on `@ConditionalOnWebApplication(SERVLET)`. But only the **aspect** is servlet-specific — store selection, the payload mapper, fingerprinting, metrics and the scope resolvers are all stack-agnostic. A reactive application got **no store at all**. The class condition is now any web application and only the aspect carries the narrower one.

## Three bugs the tests caught

Each would have shipped silently.

**1. An empty `Mono` is a legitimate response.** My first version used `switchIfEmpty` to mean "the store failed, proceed unprotected" — so a handler returning `Mono.empty()` ran a **second** time, and a replay of that stored empty response ran it a **third**. Emptiness is a valid outcome and cannot double as a control signal; the claim result now travels in an `Optional`.

**2. `ProblemDetail` does not deserialize cleanly** — it is built for writing. Every replayed 4xx became a 500. The stored body is now read as a map and reassembled, which also preserves extension members.

**3. Replaying an error as a returned `ResponseEntity` fails too.** WebFlux picks the message writer from the **declared generic type**, so a `ProblemDetail` body handed to a method declared `Mono<ResponseEntity<Map<..>>>` renders 500. Errors are re-thrown instead — as a `ResponseStatusException`, not merely something implementing `ErrorResponse`, which falls through to the generic handler and *also* renders 500.

A replayed 4xx arriving as a server error is worse than not replaying at all: the caller sees a failure that never happened.

Worth noting how #3 was found — the 5xx test was passing **for the wrong reason**. `@ResponseStatus` on the test's exceptions was not being honoured, so every error became a default 500, which happened to satisfy `is5xxServerError()`. Switching the test app to `ResponseStatusException` made the real behaviour visible.

## One place this is better than the servlet stack

`on-conflict=wait` occupies **no thread** while waiting — the delay is a timer, not a sleep. The thread-pool exhaustion documented under the servlet Limitations does not apply here.

## Limitations, all documented and enforced

- **`Mono` only.** A `Flux` is a stream and this library replays a single captured response. A `Flux`-returning handler passes through untouched with a WARN, rather than being half-supported.
- **Stores are still blocking**, so calls are scheduled onto `boundedElastic`. Correct, but an idempotent endpoint costs two thread handoffs a plain one does not. A reactive store SPI (R2DBC, reactive Redis) would remove that and is deliberately not here.
- **`idempotency.scope` must be `global`.** `user`/`tenant` resolve the principal from `SecurityContextHolder`, meaningless on this stack. Startup **fails** rather than silently falling back to global — which would share idempotency keys across users, a security problem rather than a missing feature.

## Tests

`WebFluxIdempotencyBehaviorTest` runs a real reactive server through `WebTestClient`: execute/replay, empty `Mono`, fingerprint mismatch, 5xx release, 4xx keep-and-replay, no-key passthrough, and two genuinely concurrent duplicates executing exactly once.

`./gradlew clean build`: **155 tests, 0 failures.**

## Remaining for 0.3.0

`mode: filter` — the last one.
