### PR TITLE
Add idempotency.mode=filter for byte-exact replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency.mode=filter`: byte-exact replay. Stores the real HTTP response - status, allowlisted
+  headers and body bytes - instead of the handler return value, so a body written straight to the
+  `HttpServletResponse` replays exactly. Endpoint selection stays annotation-driven and storage keys
+  are identical to aspect mode, so switching does not orphan existing records. Argument
+  fingerprinting is not available in this mode.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ a silent execution of the wrong payload.
 | Property | Default | Notes |
 |---|---|---|
 | `idempotency.enabled` | `true` | Master switch |
+| `idempotency.mode` | `aspect` | `aspect` | `filter`. See Replay modes below |
+| `idempotency.filter.replay-headers` | `Content-Type, Location, ETag, Cache-Control` | Headers replayed verbatim in filter mode |
 | `idempotency.store` | `auto` | `auto` \| `redis` \| `jdbc` \| `memory` |
 | `idempotency.default-ttl` | `24h` | Overridable per-endpoint via `@Idempotent(ttl = "...")` |
 | `idempotency.header-name` | `Idempotency-Key` | Overridable via `@Idempotent(keyHeader = "...")` |
@@ -304,6 +306,34 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## Replay modes
+
+`idempotency.mode` decides *what* gets stored and replayed. Both modes select endpoints the same
+way - `@Idempotent` on the handler - and produce identical storage keys, so switching does not
+orphan existing records.
+
+| | `aspect` (default) | `filter` |
+|---|---|---|
+| Captures | The handler return value, re-serialized on replay | The real HTTP response bytes |
+| Body written directly to `HttpServletResponse` | **Not captured** | Replayed exactly |
+| Response headers | Rebuilt from the return value | Replayed from an allowlist |
+| Argument fingerprinting | Yes - same key, different body gets a 422 | **No** - see below |
+| Runs | Inside the handler invocation | Outside the whole dispatch |
+
+Use `filter` when the exact bytes matter: a handler that streams or writes its own response, a
+content type negotiated at write time, or a header added by a filter further down the chain. Aspect
+mode cannot see any of those, because it returns before the response is written at all.
+
+Two things to know:
+
+- **No argument fingerprinting in filter mode.** That check hashes resolved method arguments, which
+  do not exist yet outside the dispatch. The equivalent would be hashing the request body, which
+  means buffering every request - a real cost on every endpoint to serve one. So in filter mode a
+  duplicate key with a *different* body replays the original response rather than getting a 422.
+- **Headers are an allowlist, not everything.** Replaying `Set-Cookie` would hand a second caller
+  the first caller's session. Add your own via `idempotency.filter.replay-headers` if clients
+  depend on them.
 
 ## Extending
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -3,6 +3,8 @@ package io.github.benhendayoussef.idempotency.config;
 import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
 import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.EnumSet;
 import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -18,6 +20,13 @@ public class IdempotencyProperties {
 
     /** Master switch. */
     private boolean enabled = true;
+
+    /**
+     * How responses are captured and replayed. ASPECT stores the handler return value and
+     * re-serializes it; FILTER stores the real HTTP response bytes, so anything written straight to
+     * the response - or added by a later filter - replays exactly. Mutually exclusive.
+     */
+    private Mode mode = Mode.ASPECT;
 
     /** Which {@code IdempotencyStore} backs replay. {@code AUTO} picks Redis when it's on the classpath. */
     private StoreType store = StoreType.AUTO;
@@ -72,6 +81,7 @@ public class IdempotencyProperties {
 
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
+    private final Filter filter = new Filter();
 
     public boolean isEnabled() {
         return enabled;
@@ -79,6 +89,14 @@ public class IdempotencyProperties {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
     }
 
     public StoreType getStore() {
@@ -193,6 +211,10 @@ public class IdempotencyProperties {
         this.releaseOn = releaseOn;
     }
 
+    public Filter getFilter() {
+        return filter;
+    }
+
     public Redis getRedis() {
         return redis;
     }
@@ -208,6 +230,28 @@ public class IdempotencyProperties {
     public enum OnMissingPrincipal { GLOBAL, SKIP, REJECT }
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
+
+    public enum Mode { ASPECT, FILTER }
+
+    public static class Filter {
+
+        /**
+         * Response headers replayed verbatim, by name. An allowlist rather than everything:
+         * replaying Set-Cookie would hand a second caller the first one's session, and replaying a
+         * stale Date or Content-Length would contradict the response actually being written. Add
+         * your own headers here if clients depend on them.
+         */
+        private List<String> replayHeaders = new ArrayList<>(List.of(
+                "Content-Type", "Location", "ETag", "Cache-Control"));
+
+        public List<String> getReplayHeaders() {
+            return replayHeaders;
+        }
+
+        public void setReplayHeaders(List<String> replayHeaders) {
+            this.replayHeaders = replayHeaders;
+        }
+    }
 
     public static class Redis {
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
@@ -6,7 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 
 /** SHA-256 hex digest, used for both storage-key composition and argument fingerprinting. */
-final class Hashing {
+public final class Hashing {
 
     private Hashing() {
     }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/CapturedResponse.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/CapturedResponse.java
@@ -1,0 +1,25 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A complete HTTP response, captured verbatim so it can be written again byte for byte.
+ *
+ * <p>This is what {@code idempotency.mode=filter} stores instead of a handler return value. The
+ * difference matters for anything the aspect mode cannot see: a response body written straight to
+ * the {@code HttpServletResponse}, a header set by a filter further down the chain, a content type
+ * negotiated at write time. Under aspect mode a replay re-serializes the return value and hopes the
+ * result matches; here there is nothing to re-derive.
+ *
+ * <p>The body is carried as Base64 rather than a string because it is bytes, not text - a binary
+ * response, or any charset other than the one that happened to be in use when it was read back,
+ * would otherwise be silently corrupted on replay.
+ *
+ * @param status  the status code as originally sent
+ * @param headers response headers worth replaying, filtered by the configured allowlist - see
+ *                {@code IdempotencyProperties.Filter#getReplayHeaders()}
+ * @param body    the raw response body, Base64-encoded
+ */
+public record CapturedResponse(int status, Map<String, List<String>> headers, String body) {
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/FilterKeyComposer.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/FilterKeyComposer.java
@@ -1,0 +1,29 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import io.github.benhendayoussef.idempotency.internal.Hashing;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Storage-key composition for filter mode.
+ *
+ * <p>Produces byte-identical keys to the aspect-mode composer for the same request. That is not
+ * incidental: switching {@code idempotency.mode} must not orphan every key already in the store, and
+ * an application running both modes across a rolling deploy has to agree with itself about what a
+ * key means.
+ */
+final class FilterKeyComposer {
+
+    private FilterKeyComposer() {
+    }
+
+    static String compose(String clientKey, String namespace, HttpServletRequest request) {
+        // The mapping lookup this filter already performed populates BEST_MATCHING_PATTERN, so the
+        // route pattern is available here exactly as the aspect sees it later.
+        String route = Objects.toString(
+                request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE),
+                request.getRequestURI());
+        return Hashing.sha256Hex(namespace + '|' + request.getMethod() + '|' + route + '|' + clientKey);
+    }
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/IdempotencyFilter.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/IdempotencyFilter.java
@@ -1,0 +1,299 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * {@code idempotency.mode=filter}: claim, replay and completion at the HTTP layer, storing the
+ * response byte for byte.
+ *
+ * <h2>Why this cannot be done in the aspect</h2>
+ *
+ * <p>The aspect runs <em>inside</em> the handler invocation, and the response body does not exist
+ * yet when it returns - message conversion happens afterwards. So aspect mode stores the handler's
+ * return value and re-serializes it on replay, which is why it cannot capture anything written
+ * directly to the {@code HttpServletResponse}, a header added further down the chain, or a content
+ * type negotiated at write time. Capturing real bytes means owning the request from outside the
+ * whole dispatch, which is what a filter is.
+ *
+ * <p>The two modes are therefore mutually exclusive: when this filter is active the aspect is not
+ * registered at all. Running both would have each claim the same key for the same request.
+ *
+ * <h2>Deciding what to protect</h2>
+ *
+ * <p>Selection stays annotation-driven - {@code @Idempotent} on the handler method, exactly as in
+ * aspect mode - rather than becoming "every POST with a key header". Two modes of the same library
+ * disagreeing about <em>which</em> endpoints are idempotent would be a far worse surprise than any
+ * difference in how they store the response.
+ *
+ * <p>That requires knowing the handler before running it, so the request is resolved against the
+ * application's {@link HandlerMapping}s up front. Spring will resolve it again during the actual
+ * dispatch; the cost is one extra mapping lookup per request that carries an idempotency key.
+ */
+public class IdempotencyFilter extends OncePerRequestFilter implements Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyFilter.class);
+
+    /** Distinguishes a raw captured response from an aspect-mode serialized return value. */
+    public static final String RAW_PAYLOAD_TYPE = "!raw";
+
+    private final IdempotencyStore store;
+    private final IdempotencyProperties props;
+    private final ObjectMapper payloadMapper;
+    private final IdempotencyMetrics metrics;
+    private final List<HandlerMapping> handlerMappings;
+
+    public IdempotencyFilter(IdempotencyStore store, IdempotencyProperties props, ObjectMapper payloadMapper,
+            IdempotencyMetrics metrics, List<HandlerMapping> handlerMappings) {
+        this.store = store;
+        this.props = props;
+        this.payloadMapper = payloadMapper;
+        this.metrics = metrics;
+        this.handlerMappings = handlerMappings;
+    }
+
+    /**
+     * Runs late enough that Spring Security has already authenticated - a 401 must never claim a key
+     * on behalf of a caller who was then rejected - but still outside the dispatcher.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 100;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        Idempotent annotation = resolveAnnotation(request);
+        if (annotation == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String headerName = annotation.keyHeader().isBlank() ? props.getHeaderName() : annotation.keyHeader();
+        String clientKey = request.getHeader(headerName);
+        if (clientKey == null || clientKey.isBlank()) {
+            metrics.missingKey();
+            if (props.isRequireKey()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "Missing required " + headerName + " header");
+                return;
+            }
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String storeKey = FilterKeyComposer.compose(clientKey, "", request);
+        Duration ttl = annotation.ttl().isBlank() ? props.getDefaultTtl()
+                : Duration.parse("PT" + annotation.ttl());
+        // Argument fingerprinting is an aspect-mode feature: it hashes the resolved method arguments,
+        // which do not exist yet out here. The request body would be the equivalent, and reading it
+        // in a filter means buffering every request - a real cost imposed on every endpoint to serve
+        // one. Documented as a difference between the modes rather than silently approximated.
+        String fingerprint = "";
+
+        ClaimResult claim;
+        try {
+            claim = store.claim(storeKey, fingerprint, ttl);
+        } catch (RuntimeException e) {
+            metrics.storeFailure();
+            if (props.getOnStoreFailure() == IdempotencyProperties.OnStoreFailure.FAIL) {
+                response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "Idempotency store unavailable");
+                return;
+            }
+            log.warn("Idempotency store unavailable; executing unprotected per idempotency.on-store-failure", e);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (claim instanceof ClaimResult.AlreadyHeld held) {
+            handleExisting(request, response, chain, held.record(), storeKey);
+            return;
+        }
+        execute(request, response, chain, storeKey, ttl);
+    }
+
+    private void execute(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+            String storeKey, Duration ttl) throws ServletException, IOException {
+        ContentCachingResponseWrapper wrapper = new ContentCachingResponseWrapper(response);
+        boolean completed = false;
+        try {
+            chain.doFilter(request, wrapper);
+
+            CapturedResponse captured = capture(wrapper);
+            if (shouldRelease(captured.status())) {
+                store.release(storeKey);
+                metrics.released();
+            } else {
+                String json = payloadMapper.writeValueAsString(captured);
+                if (json.length() > props.getMaxPayloadSize().toBytes()) {
+                    store.release(storeKey);
+                    log.warn("Idempotent response for key {} exceeds idempotency.max-payload-size; not cached",
+                            storeKey);
+                } else {
+                    store.complete(storeKey, new IdempotencyRecord(State.COMPLETED, "", captured.status(),
+                            RAW_PAYLOAD_TYPE, json, Instant.now()), ttl);
+                }
+                metrics.executed();
+            }
+            completed = true;
+        } finally {
+            if (!completed) {
+                // The chain threw before a status was ever produced, so there is nothing to store and
+                // nothing to replay. Release rather than leaving the key IN_PROGRESS for its whole
+                // TTL, which would make every retry conflict against a request that never finished.
+                releaseQuietly(storeKey);
+            }
+            // Must happen on every path: the cached body is buffered and never reaches the client
+            // until it is copied out. Skipping this on the error path would turn a handler exception
+            // into an empty response.
+            wrapper.copyBodyToResponse();
+        }
+    }
+
+    private void handleExisting(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+            IdempotencyRecord record, String storeKey) throws ServletException, IOException {
+        if (record.state() == State.COMPLETED) {
+            metrics.replayed();
+            writeReplay(response, record, false);
+            return;
+        }
+        if (props.getOnConflict() == ConflictPolicy.FAIL_FAST) {
+            metrics.conflict();
+            sendConflict(response);
+            return;
+        }
+        Optional<IdempotencyRecord> finished = waitForCompletion(storeKey);
+        if (finished.isPresent()) {
+            metrics.replayedAfterWait();
+            writeReplay(response, finished.get(), true);
+            return;
+        }
+        metrics.waitTimeout();
+        sendConflict(response);
+    }
+
+    private Optional<IdempotencyRecord> waitForCompletion(String storeKey) {
+        Instant deadline = Instant.now().plus(props.getWaitTimeout());
+        while (Instant.now().isBefore(deadline)) {
+            Optional<IdempotencyRecord> found = store.find(storeKey);
+            if (found.isPresent() && found.get().state() == State.COMPLETED) {
+                return found;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Writes the stored response back exactly as it was sent, headers and bytes included. */
+    private void writeReplay(HttpServletResponse response, IdempotencyRecord record, boolean afterWait)
+            throws IOException {
+        CapturedResponse captured = payloadMapper.readValue(record.payload(), CapturedResponse.class);
+        response.setStatus(captured.status());
+        captured.headers().forEach((name, values) -> values.forEach(v -> response.addHeader(name, v)));
+        response.setHeader("Idempotent-Replay", "true");
+        byte[] body = Base64.getDecoder().decode(captured.body());
+        if (body.length > 0) {
+            // Content-Length is set explicitly rather than left to the container: the replayed body
+            // may differ in length from whatever a stale stored header claimed.
+            response.setContentLength(body.length);
+            response.getOutputStream().write(body);
+        }
+        response.flushBuffer();
+        if (afterWait) {
+            log.debug("Replayed idempotent response after waiting for the in-flight request");
+        }
+    }
+
+    private CapturedResponse capture(ContentCachingResponseWrapper wrapper) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        List<String> allowed = props.getFilter().getReplayHeaders();
+        for (String name : wrapper.getHeaderNames()) {
+            if (allowed.stream().anyMatch(a -> a.equalsIgnoreCase(name))) {
+                headers.put(name, new ArrayList<>(wrapper.getHeaders(name)));
+            }
+        }
+        String body = Base64.getEncoder().encodeToString(wrapper.getContentAsByteArray());
+        return new CapturedResponse(wrapper.getStatus(), headers, body);
+    }
+
+    private boolean shouldRelease(int status) {
+        return status >= 500 && props.getReleaseOn().contains(IdempotencyProperties.ReleaseOn.FIVE_XX);
+    }
+
+    private void sendConflict(HttpServletResponse response) throws IOException {
+        response.setHeader("Retry-After", String.valueOf(Math.max(1, props.getWaitTimeout().toSeconds())));
+        response.sendError(HttpServletResponse.SC_CONFLICT, "A request with this idempotency key is in progress");
+    }
+
+    private void releaseQuietly(String storeKey) {
+        try {
+            store.release(storeKey);
+        } catch (RuntimeException e) {
+            log.warn("Failed to release idempotency key {} after a failed request; it will expire with its TTL",
+                    storeKey, e);
+        }
+    }
+
+    /**
+     * Finds {@code @Idempotent} on the handler this request would dispatch to, without dispatching.
+     *
+     * <p>Returns null - meaning "not our business" - for anything unmapped, any non-handler-method
+     * target such as a static resource, and any exception during resolution. A filter that failed
+     * requests because it could not work out whether they were idempotent would be far worse than
+     * one that occasionally declines to protect a request.
+     */
+    private Idempotent resolveAnnotation(HttpServletRequest request) {
+        for (HandlerMapping mapping : handlerMappings) {
+            try {
+                HandlerExecutionChain chain = mapping.getHandler(request);
+                if (chain == null) {
+                    continue;
+                }
+                if (chain.getHandler() instanceof HandlerMethod handlerMethod) {
+                    return handlerMethod.getMethodAnnotation(Idempotent.class);
+                }
+                return null;
+            } catch (Exception e) {
+                log.debug("Handler resolution failed while checking for @Idempotent; "
+                        + "treating the request as not idempotent", e);
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,126 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.mode",
+      "description": "How responses are captured and replayed. ASPECT stores the handler return value and re-serializes it on replay; FILTER stores the real HTTP response bytes, so a body written straight to the response and allowlisted headers replay exactly. Mutually exclusive - exactly one is registered."
+    },
+    {
+      "name": "idempotency.filter.replay-headers",
+      "description": "Response headers replayed verbatim in filter mode, by name. An allowlist: replaying Set-Cookie would hand a second caller the first caller session."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
+      ]
+    },
+    {
+      "name": "idempotency.mode",
+      "values": [
+        {
+          "value": "aspect",
+          "description": "Default. Captures the handler return value; cannot see anything written directly to the response."
+        },
+        {
+          "value": "filter",
+          "description": "Byte-exact replay of the real HTTP response. No argument fingerprinting."
+        }
       ]
     }
   ]

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 
     compileOnly("org.springframework.data:spring-data-redis")
     compileOnly("org.springframework:spring-jdbc")
+    // For HandlerMapping, referenced when wiring the filter-mode bean. Servlet MVC is
+    // always present at runtime under @ConditionalOnWebApplication(SERVLET), so compileOnly.
+    compileOnly("org.springframework:spring-webmvc")
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -15,6 +15,7 @@ import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyExceptionHandler;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyKeyComposer;
 import io.github.benhendayoussef.idempotency.internal.InMemoryIdempotencyStore;
+import io.github.benhendayoussef.idempotency.internal.filter.IdempotencyFilter;
 import io.github.benhendayoussef.idempotency.internal.NoOpIdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.internal.scope.GlobalScopeResolver;
@@ -45,6 +46,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -137,8 +139,11 @@ public class IdempotencyAutoConfiguration {
         return map;
     }
 
+    // ASPECT is the default, and matchIfMissing keeps an application that never set idempotency.mode
+    // on exactly the behaviour it had before the property existed.
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "idempotency", name = "mode", havingValue = "aspect", matchIfMissing = true)
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,
@@ -156,6 +161,22 @@ public class IdempotencyAutoConfiguration {
         }
         return new IdempotencyAspect(store, props, fingerprinter, composer, scopes,
                 idempotencyPayloadObjectMapper, metrics, runner);
+    }
+
+    /**
+     * Filter mode. Mutually exclusive with the aspect above by property value, so exactly one of the
+     * two is ever registered - running both would have each claim the same key for the same request.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "idempotency", name = "mode", havingValue = "filter")
+    public IdempotencyFilter idempotencyFilter(IdempotencyStore store, IdempotencyProperties props,
+            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics,
+            ObjectProvider<HandlerMapping> handlerMappings) {
+        // ObjectProvider, not a direct List injection: the filter is created while the mapping beans
+        // are still being built, and demanding them eagerly here deadlocks context startup.
+        return new IdempotencyFilter(store, props, idempotencyPayloadObjectMapper, metrics,
+                handlerMappings.orderedStream().toList());
     }
 
     @Bean

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
@@ -1,0 +1,313 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
+import io.github.benhendayoussef.idempotency.internal.filter.IdempotencyFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * {@code idempotency.mode=filter}: byte-exact replay.
+ *
+ * <p>The tests that matter here are the ones aspect mode <strong>cannot</strong> pass - a body
+ * written straight to the {@code HttpServletResponse}, and headers the handler set that are not part
+ * of any return value. Those are the documented reasons this mode exists, so proving replay works
+ * for an ordinary {@code ResponseEntity} would say almost nothing.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = FilterModeBehaviorTest.FilterApp.class,
+        properties = {"idempotency.mode=filter", "idempotency.store=memory",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+@AutoConfigureMockMvc
+class FilterModeBehaviorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RawController controller;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @BeforeEach
+    void reset() {
+        controller.reset();
+    }
+
+    /**
+     * The modes must never both be active: each would claim the same key for the same request, and
+     * the second would see the first one holding it.
+     */
+    @Test
+    void filterModeReplacesTheAspectRatherThanRunningAlongsideIt() {
+        assertThat(context.getBeanNamesForType(IdempotencyFilter.class)).hasSize(1);
+        assertThat(context.getBeanNamesForType(IdempotencyAspect.class))
+                .as("the aspect must be absent in filter mode")
+                .isEmpty();
+    }
+
+    /**
+     * The headline case. This handler writes bytes directly to the response and returns void, so
+     * there is no return value for aspect mode to capture - the README lists it as a limitation.
+     * Filter mode records the actual bytes, so the replay is identical.
+     */
+    @Test
+    void aBodyWrittenDirectlyToTheResponseIsReplayedByteForByte() throws Exception {
+        String key = "raw-" + System.nanoTime();
+
+        String first = mockMvc.perform(post("/f/raw").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        String replayed = mockMvc.perform(post("/f/raw").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Idempotent-Replay", "true"))
+                .andReturn().getResponse().getContentAsString();
+
+        assertThat(replayed).isEqualTo(first);
+        assertThat(first).isEqualTo("written-straight-to-the-response");
+        assertThat(controller.rawCount())
+                .as("the duplicate must be answered from the store, not re-executed")
+                .isEqualTo(1);
+    }
+
+    /** A header the handler set is part of the response, and must survive a replay. */
+    @Test
+    void headersOnTheAllowlistAreReplayed() throws Exception {
+        String key = "hdr-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/orders/42"));
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/orders/42"))
+                .andExpect(header().string("Idempotent-Replay", "true"));
+
+        assertThat(controller.createdCount()).isEqualTo(1);
+    }
+
+    /**
+     * The allowlist is a safety property, not a tuning knob. Replaying {@code Set-Cookie} would hand
+     * a second caller the first caller's session.
+     */
+    @Test
+    void headersOffTheAllowlistAreNotReplayed() throws Exception {
+        String key = "cookie-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/cookie").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", "SESSION=secret-for-caller-one"));
+
+        mockMvc.perform(post("/f/cookie").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Set-Cookie"));
+    }
+
+    @Test
+    void theStatusCodeIsReplayedExactly() throws Exception {
+        String key = "status-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void a5xxReleasesTheKeySoARetryReExecutes() throws Exception {
+        String key = "5xx-" + System.nanoTime();
+        controller.failNext();
+
+        mockMvc.perform(post("/f/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isInternalServerError());
+        mockMvc.perform(post("/f/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk());
+
+        assertThat(controller.flakyCount()).isEqualTo(2);
+    }
+
+    @Test
+    void a4xxIsKeptAndReplayed() throws Exception {
+        String key = "4xx-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/bad").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(post("/f/bad").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(controller.badCount())
+                .as("a deterministic client error is replayed, not re-executed")
+                .isEqualTo(1);
+    }
+
+    /** An endpoint without the annotation must be left completely alone, key header or not. */
+    @Test
+    void anUnannotatedEndpointIsUntouched() throws Exception {
+        String key = "plain-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/plain").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Idempotent-Replay"));
+        mockMvc.perform(post("/f/plain").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk());
+
+        assertThat(controller.plainCount()).isEqualTo(2);
+    }
+
+    @Test
+    void aRequestWithNoKeyExecutesEveryTime() throws Exception {
+        mockMvc.perform(post("/f/created").contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/f/created").contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+
+        assertThat(controller.createdCount()).isEqualTo(2);
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class FilterApp {
+        @Bean
+        RawController rawController() {
+            return new RawController();
+        }
+    }
+
+    @RestController
+    static class RawController {
+        private final AtomicInteger raw = new AtomicInteger();
+        private final AtomicInteger created = new AtomicInteger();
+        private final AtomicInteger cookie = new AtomicInteger();
+        private final AtomicInteger flaky = new AtomicInteger();
+        private final AtomicInteger bad = new AtomicInteger();
+        private final AtomicInteger plain = new AtomicInteger();
+        private final java.util.concurrent.atomic.AtomicBoolean failNext =
+                new java.util.concurrent.atomic.AtomicBoolean();
+
+        void reset() {
+            raw.set(0);
+            created.set(0);
+            cookie.set(0);
+            flaky.set(0);
+            bad.set(0);
+            plain.set(0);
+            failNext.set(false);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        int rawCount() {
+            return raw.get();
+        }
+
+        int createdCount() {
+            return created.get();
+        }
+
+        int flakyCount() {
+            return flaky.get();
+        }
+
+        int badCount() {
+            return bad.get();
+        }
+
+        int plainCount() {
+            return plain.get();
+        }
+
+        /** Writes to the response and returns void: nothing for aspect mode to capture. */
+        @Idempotent
+        @PostMapping("/f/raw")
+        void raw(@RequestBody Map<String, Object> body, HttpServletResponse response) throws IOException {
+            raw.incrementAndGet();
+            response.setStatus(HttpStatus.OK.value());
+            response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+            response.getOutputStream().write("written-straight-to-the-response".getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Idempotent
+        @PostMapping("/f/created")
+        ResponseEntity<Map<String, Object>> created(@RequestBody Map<String, Object> body) {
+            created.incrementAndGet();
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .header("Location", "/orders/42")
+                    .body(Map.of("id", 42));
+        }
+
+        @Idempotent
+        @PostMapping("/f/cookie")
+        ResponseEntity<Map<String, Object>> withCookie(@RequestBody Map<String, Object> body) {
+            cookie.incrementAndGet();
+            return ResponseEntity.ok()
+                    .header("Set-Cookie", "SESSION=secret-for-caller-one")
+                    .body(Map.of("ok", true));
+        }
+
+        @Idempotent
+        @PostMapping("/f/flaky")
+        ResponseEntity<Map<String, Object>> flaky(@RequestBody Map<String, Object> body) {
+            flaky.incrementAndGet();
+            if (failNext.compareAndSet(true, false)) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("err", true));
+            }
+            return ResponseEntity.ok(Map.of("ok", true));
+        }
+
+        @Idempotent
+        @PostMapping("/f/bad")
+        ResponseEntity<Map<String, Object>> bad(@RequestBody Map<String, Object> body) {
+            bad.incrementAndGet();
+            return ResponseEntity.badRequest().body(Map.of("err", "nope"));
+        }
+
+        @PostMapping("/f/plain")
+        ResponseEntity<Map<String, Object>> plain(@RequestBody Map<String, Object> body) {
+            plain.incrementAndGet();
+            return ResponseEntity.ok(Map.of("ok", true));
+        }
+    }
+}


### PR DESCRIPTION
Sixth and last of the items scoped for 0.3.0.

## Why this cannot be the aspect

Aspect mode stores the handler **return value** and re-serializes it on replay. That is why the README lists, as a limitation, that it cannot capture a body written straight to the `HttpServletResponse`, a header added further down the chain, or a content type negotiated at write time.

The reason is structural: the aspect runs *inside* the handler invocation, and the response body does not exist yet when it returns — message conversion happens afterwards. Capturing real bytes means owning the request from outside the whole dispatch, which is a filter.

The two modes are mutually exclusive by property value, so exactly one is ever registered. Both would otherwise claim the same key for the same request. There is a test asserting the aspect bean is absent in filter mode.

## Selection stays annotation-driven

The easy implementation would treat "every POST carrying a key header" as idempotent. I did not: two modes of the same library disagreeing about **which** endpoints are idempotent would be a far worse surprise than any difference in how they store the response.

So the filter resolves the request against the application's `HandlerMapping`s up front to find `@Idempotent`. Cost is one extra mapping lookup per request that carries a key. Resolution failures are treated as "not idempotent" rather than propagated — a filter that failed requests because it could not work out whether to protect them would be worse than one that occasionally declines to.

**Storage keys are byte-identical to aspect mode**, so switching modes does not orphan records already in the store.

## Details worth reviewing

- **Headers are an allowlist**, not everything. Replaying `Set-Cookie` would hand a second caller the first caller's session — there is a test for exactly that.
- **The body is stored Base64-encoded** because it is bytes, not text. A binary response would otherwise be corrupted by whatever charset happened to be in use reading it back.
- **`copyBodyToResponse()` runs in a `finally`.** The cached body is buffered and never reaches the client until copied out, so skipping it on the error path would turn a handler exception into an empty response.
- **A claim is released if the chain throws** before producing a status, rather than left `IN_PROGRESS` for its whole TTL — otherwise every retry would conflict against a request that never finished.

## One capability this mode does not have

**Argument fingerprinting.** It hashes resolved method arguments, which do not exist outside the dispatch. The equivalent would be hashing the request body, which means buffering every request — a real cost on every endpoint to serve one. So in filter mode, a duplicate key with a *different* body replays the original response instead of returning 422.

Documented as a mode difference rather than silently approximated.

## Tests

The tests that matter are the ones aspect mode **cannot** pass — proving replay works for an ordinary `ResponseEntity` would say almost nothing. Covered: a body written directly to the response replaying byte for byte, allowlisted headers replayed, `Set-Cookie` *not* replayed, exact status, 5xx release, 4xx keep-and-replay, unannotated endpoints untouched, no-key passthrough, and the two modes never coexisting.

`./gradlew clean build`: **156 tests, 0 failures.**

## That completes 0.3.0

All six: Boot 3 (#4), Micrometer (#5), MySQL (#6), Caffeine (#7), WebFlux (#8), filter mode (#9).
