### PR TITLE
0.3.0: integrate all six features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
 
 jobs:
   build:
+    # The whole suite runs against both supported Spring Boot generations from one source tree.
+    # Nothing in the library is version-specific - the matrix exists to keep it that way, since the
+    # ways these two diverge (autoconfiguration package renames, which ObjectMapper wins
+    # @ConditionalOnMissingBean) all fail silently rather than at compile time.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The lower bound, and what the published artifacts are compiled against.
+          - spring-boot: '3.5.6'
+            label: 'Spring Boot 3.5'
+          - spring-boot: '4.1.0'
+            label: 'Spring Boot 4.1'
+
+    name: ${{ matrix.label }}
+
     # Docker is preinstalled on GitHub-hosted ubuntu-latest runners, required for the
     # Testcontainers-backed idempotency-store-redis/idempotency-store-jdbc test suites.
     runs-on: ubuntu-latest
@@ -23,7 +39,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
-        run: ./gradlew clean build
+        run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} clean build
 
       # Virtual threads don't exist on the project's pinned Java 17 toolchain; this task runs the
       # same test sources on a separately-provisioned JDK 21+ launcher without changing what the
@@ -35,11 +51,11 @@ jobs:
           java-version: '21'
 
       - name: Virtual threads check
-        run: ./gradlew :idempotency-spring-boot-starter:testVirtualThreads
+        run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} :idempotency-spring-boot-starter:testVirtualThreads
 
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-boot-${{ matrix.spring-boot }}
           path: '**/build/reports/tests/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency-store-caffeine`: a single-instance store with real TTL eviction and a bounded size
+  (`idempotency.caffeine.maximum-size`). The built-in `store=memory` treats expired entries as
+  absent but never removes them, so it grows for the life of the process - fine for tests, a slow
+  leak for a service that stays up.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency.mode=filter`: byte-exact replay. Stores the real HTTP response - status, allowlisted
+  headers and body bytes - instead of the handler return value, so a body written straight to the
+  `HttpServletResponse` replays exactly. Endpoint selection stays annotation-driven and storage keys
+  are identical to aspect mode, so switching does not orphan existing records. Argument
+  fingerprinting is not available in this mode.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `idempotency-webflux`: `@Idempotent` on reactive handlers returning `Mono`. The WAIT policy holds
+  no thread on this stack. Limitations, all documented: `Mono` only, blocking stores scheduled onto
+  `boundedElastic`, and `idempotency.scope=global` only - a non-global scope fails startup rather
+  than silently sharing keys across users.
+
+### Fixed
+
+- `IdempotencyAutoConfiguration` was gated entirely on a servlet web application, so everything in
+  it - store selection, the payload mapper, fingerprinting, metrics - was unavailable to any
+  non-servlet stack. Only the servlet aspect needed that condition.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Micrometer metrics, wired automatically when the application has a `MeterRegistry`. Every outcome
+  lands on one counter, `idempotency.requests`, tagged by `outcome` - so a replay rate is a single
+  ratio rather than a hard-coded list of metric names. `idempotency.metrics.enabled=false` opts out;
+  a user-supplied `IdempotencyMetrics` bean still wins.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ spring:
   sql:
     init:
       mode: always
-      schema-locations: classpath:db/idempotency/postgres.sql # ships inside idempotency-store-jdbc
+      schema-locations: classpath:db/idempotency/postgres.sql # or mysql.sql - both ship inside idempotency-store-jdbc
 idempotency:
   store: jdbc   # required: AUTO never selects JDBC on its own, even with no Redis present
 ```
@@ -127,17 +127,18 @@ a silent execution of the wrong payload.
 | `idempotency.release-on` | `five_xx,timeout` | Outcomes that release instead of complete the key. Note the underscore: Spring's relaxed binding needs `five_xx`, not `5xx` |
 | `idempotency.redis.key-prefix` | `idempotency:` | |
 | `idempotency.jdbc.table-name` | `idempotency_record` | |
+| `idempotency.jdbc.dialect` | `auto` | `auto` | `postgres` | `mysql`. AUTO detects from the `DataSource` on first use, not at startup |
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
 | `idempotency.jdbc.sweeper-interval` | `15m` | |
 | `idempotency.jdbc.join-transaction` | `false` | Run the handler and the completion write in one shared transaction — exactly-once instead of at-least-once. Costs: non-`@Transactional` handlers get pulled into a transaction, and a handler's own `@Transactional(timeout)` stops applying. [Read the caveats first](#opt-in-exactly-once-via-transaction-joining) |
 
 ## Store comparison
 
-| | Redis | JDBC (Postgres) |
+| | Redis | JDBC (Postgres / MySQL) |
 |---|---|---|
 | Guarantee | **At-least-once.** If the process crashes between the business transaction committing and the completion record being written, the key stays `IN_PROGRESS` until TTL and a retry re-executes. | **At-least-once by default; exactly-once with `idempotency.jdbc.join-transaction=true`.** Both modes are described below — read them before switching. |
 | Speed | Fast — a single round trip per claim. | Slower — shares the datasource and transaction. |
-| Setup | `spring-boot-starter-data-redis` | A `DataSource`, `idempotency.store=jdbc`, and `db/idempotency/postgres.sql` applied — see the JDBC quickstart above |
+| Setup | `spring-boot-starter-data-redis` | A `DataSource`, `idempotency.store=jdbc`, and the schema for your database applied — see the JDBC quickstart above |
 | Good for | The other 95% of use cases. | Payments and anything else where a replayed side effect is unacceptable, **if you use it the way described below.** |
 
 **Measured overhead** (200 requests, 20 warmup iterations, real Redis/Postgres via Testcontainers on
@@ -253,7 +254,7 @@ Being loud about these is what makes a library trustworthy:
   anything the handler writes directly to `HttpServletResponse` is not captured.
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
-- Postgres only for the JDBC store (MySQL is on the roadmap).
+- The JDBC store supports PostgreSQL and MySQL/MariaDB. Other engines need a new dialect.
 - Servlet stack only (WebFlux is on the roadmap).
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Being loud about these is what makes a library trustworthy:
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
 - Postgres only for the JDBC store (MySQL is on the roadmap).
-- Servlet stack only (WebFlux is on the roadmap).
+- WebFlux support covers `Mono` only, with a blocking store on `boundedElastic` and `scope=global`. See the WebFlux section.
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.
 - `idempotency.scope` defaults to `global` (no Spring Security needed) precisely so the Quickstart
@@ -304,6 +304,44 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## WebFlux
+
+Add `idempotency-webflux` and `@Idempotent` works on reactive handlers that return `Mono`:
+
+```kotlin
+dependencies {
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.3.0")
+    implementation("io.github.benhendayoussef:idempotency-webflux:0.3.0")
+    implementation("io.github.benhendayoussef:idempotency-store-redis:0.3.0")
+}
+```
+
+```java
+@Idempotent
+@PostMapping("/orders")
+public Mono<ResponseEntity<OrderResponse>> placeOrder(@RequestBody OrderRequest request) { ... }
+```
+
+Nothing else to configure. The servlet and reactive aspects are mutually exclusive by construction,
+so an application gets exactly one.
+
+One thing is genuinely better here: `on-conflict=wait` occupies **no thread** while it waits, because
+the delay is a timer rather than a sleep. The thread-pool exhaustion documented under Limitations for
+the servlet stack does not apply.
+
+Three things to know before adopting it:
+
+- **Only `Mono` is advised.** A `Flux` is a stream, and this library replays a single captured
+  response - the same reason the servlet side does not support streaming. A `Flux`-returning handler
+  passes through untouched, with a WARN at startup rather than silent half-support.
+- **Stores are still blocking**, so store calls are scheduled onto `boundedElastic`. Correct, but an
+  idempotent endpoint costs two thread handoffs a plain one does not. A reactive store SPI (R2DBC,
+  reactive Redis) would remove that and is not in 0.3.0.
+- **`idempotency.scope` must be `global`.** `user` and `tenant` resolve the principal from
+  `SecurityContextHolder`, which is a ThreadLocal with no meaning on a reactive stack. Rather than
+  quietly falling back to global - which would share idempotency keys across users - startup fails
+  with an explanation.
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,13 @@ app's own `ObjectMapper`).
 
 | Starter version | Spring Boot | Java |
 |---|---|---|
+| 0.3.x | **3.5.x and 4.1.x** | 17+ |
 | 0.2.x | 4.1.x (Spring Framework 7) | 17+ |
 | 0.1.x | 4.1.x (Spring Framework 7) | 17+ |
+
+From 0.3.0 there is **one artifact for both Spring Boot generations** - no `-boot3` classifier and no
+separate version line. Every Spring API the library uses exists in both, so it is compiled against the
+lower bound and the full suite runs against both in CI on every push.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ a silent execution of the wrong payload.
 | `idempotency.problem-details` | `true` | Registers the built-in RFC 9457 exception advice |
 | `idempotency.max-payload-size` | `256KB` | Larger responses execute normally but aren't cached for replay |
 | `idempotency.release-on` | `five_xx,timeout` | Outcomes that release instead of complete the key. Note the underscore: Spring's relaxed binding needs `five_xx`, not `5xx` |
+| `idempotency.caffeine.maximum-size` | `10000` | Ceiling on entries held by the Caffeine store; LRU beyond it |
 | `idempotency.redis.key-prefix` | `idempotency:` | |
 | `idempotency.jdbc.table-name` | `idempotency_record` | |
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
@@ -254,6 +255,9 @@ Being loud about these is what makes a library trustworthy:
 - Does not work on streaming / SSE / `StreamingResponseBody` returns.
 - Does not handle multipart bodies in the fingerprint.
 - Postgres only for the JDBC store (MySQL is on the roadmap).
+- `store=memory` never evicts expired entries, so it grows for as long as the process lives. It is
+  meant for tests and local development. For a single instance that stays up, use `store=caffeine`,
+  which has the same semantics plus real TTL eviction and a size ceiling.
 - Servlet stack only (WebFlux is on the roadmap).
 - AOP-based: self-invocation bypasses the proxy, same as `@Transactional`. A startup check warns
   if `@Idempotent` is found on a non-public method.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ a silent execution of the wrong payload.
 | Property | Default | Notes |
 |---|---|---|
 | `idempotency.enabled` | `true` | Master switch |
+| `idempotency.mode` | `aspect` | `aspect` | `filter`. See Replay modes below |
+| `idempotency.filter.replay-headers` | `Content-Type, Location, ETag, Cache-Control` | Headers replayed verbatim in filter mode |
 | `idempotency.store` | `auto` | `auto` \| `redis` \| `jdbc` \| `memory` |
 | `idempotency.default-ttl` | `24h` | Overridable per-endpoint via `@Idempotent(ttl = "...")` |
 | `idempotency.header-name` | `Idempotency-Key` | Overridable via `@Idempotent(keyHeader = "...")` |
@@ -304,6 +306,34 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## Replay modes
+
+`idempotency.mode` decides *what* gets stored and replayed. Both modes select endpoints the same
+way - `@Idempotent` on the handler - and produce identical storage keys, so switching does not
+orphan existing records.
+
+| | `aspect` (default) | `filter` |
+|---|---|---|
+| Captures | The handler return value, re-serialized on replay | The real HTTP response bytes |
+| Body written directly to `HttpServletResponse` | **Not captured** | Replayed exactly |
+| Response headers | Rebuilt from the return value | Replayed from an allowlist |
+| Argument fingerprinting | Yes - same key, different body gets a 422 | **No** - see below |
+| Runs | Inside the handler invocation | Outside the whole dispatch |
+
+Use `filter` when the exact bytes matter: a handler that streams or writes its own response, a
+content type negotiated at write time, or a header added by a filter further down the chain. Aspect
+mode cannot see any of those, because it returns before the response is written at all.
+
+Two things to know:
+
+- **No argument fingerprinting in filter mode.** That check hashes resolved method arguments, which
+  do not exist yet outside the dispatch. The equivalent would be hashing the request body, which
+  means buffering every request - a real cost on every endpoint to serve one. So in filter mode a
+  duplicate key with a *different* body replays the original response rather than getting a 422.
+- **Headers are an allowlist, not everything.** Replaying `Set-Cookie` would hand a second caller
+  the first caller's session. Add your own via `idempotency.filter.replay-headers` if clients
+  depend on them.
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ a silent execution of the wrong payload.
 | `idempotency.jdbc.sweeper-enabled` | `false` | The atomic claim already reclaims expired rows on the hot path; this is only for disk usage |
 | `idempotency.jdbc.sweeper-interval` | `15m` | |
 | `idempotency.jdbc.join-transaction` | `false` | Run the handler and the completion write in one shared transaction — exactly-once instead of at-least-once. Costs: non-`@Transactional` handlers get pulled into a transaction, and a handler's own `@Transactional(timeout)` stops applying. [Read the caveats first](#opt-in-exactly-once-via-transaction-joining) |
+| `idempotency.metrics.enabled` | `true` | Publish counters to Micrometer when a `MeterRegistry` exists. No effect without one |
 
 ## Store comparison
 
@@ -304,6 +305,39 @@ polymorphic-deserialization gadget vector.
 - [`docs/design-decisions.md`](docs/design-decisions.md) — the architectural reasoning: why AOP
   over a servlet filter, the atomic claim, the failure policy, and what "exactly-once" does and
   doesn't mean here.
+
+## Metrics
+
+If your application already has a Micrometer `MeterRegistry` (adding `spring-boot-starter-actuator`
+is enough), the starter publishes counters automatically. There is nothing to configure.
+
+Everything lands on **one** counter, `idempotency.requests`, separated by an `outcome` tag:
+
+| `outcome` | Meaning |
+|---|---|
+| `executed` | Handler ran; the response was stored for replay |
+| `replayed` | A duplicate was answered from the store without executing |
+| `replayed_after_wait` | A `WAIT`-policy duplicate blocked, then replayed the first call’s response |
+| `released` | The key was released so a retry can re-execute (5xx, or a timeout) |
+| `conflict` | A duplicate arrived while the first was in flight and got a 409 |
+| `wait_timeout` | A `WAIT`-policy duplicate gave up waiting |
+| `fingerprint_mismatch` | Same key, different request body - the 422 case |
+| `missing_key` | No idempotency key on the request |
+| `store_failure` | The store was unreachable |
+| `principal_missing` | A `user`/`tenant`-scoped request had no resolvable principal |
+
+One name with a tag rather than ten names is deliberate: it lets you write a replay rate as a single
+ratio, and an outcome added in a later version shows up in your existing queries instead of being
+invisible until you update them.
+
+```promql
+# Replay rate: the share of idempotent traffic served without re-executing
+sum(rate(idempotency_requests_total{outcome="replayed"}[5m]))
+  / sum(rate(idempotency_requests_total[5m]))
+```
+
+Set `idempotency.metrics.enabled=false` to keep the no-op implementation, or register your own
+`IdempotencyMetrics` bean to route the same events somewhere else - the starter backs off from both.
 
 ## Extending
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,19 @@ subprojects {
 
     repositories { mavenCentral() }
 
+    // The Boot generation under test is a build parameter so CI can run the whole suite against
+    // both Spring Boot 3.x and 4.x from one source tree. The version catalog supplies the default;
+    // -PspringBootVersion=3.5.6 overrides it. Published artifacts are compiled against the lower
+    // bound (see the compatibility matrix in the README), which is what makes one artifact work on
+    // both - every Spring API this library touches exists in both generations.
+    val springBootVersion = providers.gradleProperty("springBootVersion")
+        .getOrElse(rootProject.libs.versions.springBoot.get())
+    val springBootBom = "org.springframework.boot:spring-boot-dependencies:$springBootVersion"
+
     dependencies {
-        add("implementation", platform(rootProject.libs.spring.boot.dependencies))
-        add("annotationProcessor", platform(rootProject.libs.spring.boot.dependencies))
-        add("testImplementation", platform(rootProject.libs.spring.boot.dependencies))
+        add("implementation", platform(springBootBom))
+        add("annotationProcessor", platform(springBootBom))
+        add("testImplementation", platform(springBootBom))
         add("testImplementation", platform(rootProject.libs.testcontainers.bom))
         add("testImplementation", rootProject.libs.assertj.core)
         add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -73,6 +73,8 @@ public class IdempotencyProperties {
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
 
+    private final Metrics metrics = new Metrics();
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -197,6 +199,10 @@ public class IdempotencyProperties {
         return redis;
     }
 
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
     public Jdbc getJdbc() {
         return jdbc;
     }
@@ -276,6 +282,24 @@ public class IdempotencyProperties {
 
         public void setJoinTransaction(boolean joinTransaction) {
             this.joinTransaction = joinTransaction;
+        }
+    }
+
+    public static class Metrics {
+
+        /**
+         * Publish idempotency counters to Micrometer when a MeterRegistry is present. Set false to
+         * keep the no-op implementation even in an application that has a registry - for instance
+         * where cardinality budgets are tight and these counters are not wanted.
+         */
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -72,6 +72,7 @@ public class IdempotencyProperties {
 
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
+    private final Caffeine caffeine = new Caffeine();
 
     public boolean isEnabled() {
         return enabled;
@@ -193,6 +194,10 @@ public class IdempotencyProperties {
         this.releaseOn = releaseOn;
     }
 
+    public Caffeine getCaffeine() {
+        return caffeine;
+    }
+
     public Redis getRedis() {
         return redis;
     }
@@ -201,13 +206,32 @@ public class IdempotencyProperties {
         return jdbc;
     }
 
-    public enum StoreType { AUTO, REDIS, JDBC, MEMORY }
+    public enum StoreType { AUTO, REDIS, JDBC, CAFFEINE, MEMORY }
 
     public enum OnStoreFailure { PROCEED, FAIL }
 
     public enum OnMissingPrincipal { GLOBAL, SKIP, REJECT }
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
+
+    public static class Caffeine {
+
+        /**
+         * Ceiling on entries held. Eviction normally happens by TTL; this is the backstop for when
+         * new keys arrive faster than old ones expire, so memory stays bounded instead of tracking
+         * traffic. Least-recently-used entries go first, which for idempotency keys means the ones
+         * least likely to still be retried.
+         */
+        private long maximumSize = 10_000;
+
+        public long getMaximumSize() {
+            return maximumSize;
+        }
+
+        public void setMaximumSize(long maximumSize) {
+            this.maximumSize = maximumSize;
+        }
+    }
 
     public static class Redis {
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -3,6 +3,8 @@ package io.github.benhendayoussef.idempotency.config;
 import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
 import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.EnumSet;
 import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -18,6 +20,13 @@ public class IdempotencyProperties {
 
     /** Master switch. */
     private boolean enabled = true;
+
+    /**
+     * How responses are captured and replayed. ASPECT stores the handler return value and
+     * re-serializes it; FILTER stores the real HTTP response bytes, so anything written straight to
+     * the response - or added by a later filter - replays exactly. Mutually exclusive.
+     */
+    private Mode mode = Mode.ASPECT;
 
     /** Which {@code IdempotencyStore} backs replay. {@code AUTO} picks Redis when it's on the classpath. */
     private StoreType store = StoreType.AUTO;
@@ -72,6 +81,7 @@ public class IdempotencyProperties {
 
     private final Redis redis = new Redis();
     private final Jdbc jdbc = new Jdbc();
+    private final Filter filter = new Filter();
 
     public boolean isEnabled() {
         return enabled;
@@ -79,6 +89,14 @@ public class IdempotencyProperties {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
     }
 
     public StoreType getStore() {
@@ -193,6 +211,10 @@ public class IdempotencyProperties {
         this.releaseOn = releaseOn;
     }
 
+    public Filter getFilter() {
+        return filter;
+    }
+
     public Redis getRedis() {
         return redis;
     }
@@ -208,6 +230,28 @@ public class IdempotencyProperties {
     public enum OnMissingPrincipal { GLOBAL, SKIP, REJECT }
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
+
+    public enum Mode { ASPECT, FILTER }
+
+    public static class Filter {
+
+        /**
+         * Response headers replayed verbatim, by name. An allowlist rather than everything:
+         * replaying Set-Cookie would hand a second caller the first one's session, and replaying a
+         * stale Date or Content-Length would contradict the response actually being written. Add
+         * your own headers here if clients depend on them.
+         */
+        private List<String> replayHeaders = new ArrayList<>(List.of(
+                "Content-Type", "Location", "ETag", "Cache-Control"));
+
+        public List<String> getReplayHeaders() {
+            return replayHeaders;
+        }
+
+        public void setReplayHeaders(List<String> replayHeaders) {
+            this.replayHeaders = replayHeaders;
+        }
+    }
 
     public static class Redis {
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/config/IdempotencyProperties.java
@@ -209,6 +209,8 @@ public class IdempotencyProperties {
 
     public enum ReleaseOn { FIVE_XX, TIMEOUT }
 
+    public enum Dialect { AUTO, POSTGRES, MYSQL }
+
     public static class Redis {
 
         /** Prefix applied to every Redis key the store writes. */
@@ -246,6 +248,14 @@ public class IdempotencyProperties {
          */
         private boolean joinTransaction = false;
 
+        /**
+         * Which SQL dialect the store speaks. AUTO asks the DataSource what it is connected to at
+         * startup, which is right almost always; set it explicitly for a database that reports a
+         * product name AUTO does not recognise, or to fail fast on a misconfigured DataSource
+         * rather than silently getting the wrong SQL.
+         */
+        private Dialect dialect = Dialect.AUTO;
+
         public String getTableName() {
             return tableName;
         }
@@ -268,6 +278,14 @@ public class IdempotencyProperties {
 
         public void setSweeperInterval(Duration sweeperInterval) {
             this.sweeperInterval = sweeperInterval;
+        }
+
+        public Dialect getDialect() {
+            return dialect;
+        }
+
+        public void setDialect(Dialect dialect) {
+            this.dialect = dialect;
         }
 
         public boolean isJoinTransaction() {

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/Hashing.java
@@ -6,7 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 
 /** SHA-256 hex digest, used for both storage-key composition and argument fingerprinting. */
-final class Hashing {
+public final class Hashing {
 
     private Hashing() {
     }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/CapturedResponse.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/CapturedResponse.java
@@ -1,0 +1,25 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A complete HTTP response, captured verbatim so it can be written again byte for byte.
+ *
+ * <p>This is what {@code idempotency.mode=filter} stores instead of a handler return value. The
+ * difference matters for anything the aspect mode cannot see: a response body written straight to
+ * the {@code HttpServletResponse}, a header set by a filter further down the chain, a content type
+ * negotiated at write time. Under aspect mode a replay re-serializes the return value and hopes the
+ * result matches; here there is nothing to re-derive.
+ *
+ * <p>The body is carried as Base64 rather than a string because it is bytes, not text - a binary
+ * response, or any charset other than the one that happened to be in use when it was read back,
+ * would otherwise be silently corrupted on replay.
+ *
+ * @param status  the status code as originally sent
+ * @param headers response headers worth replaying, filtered by the configured allowlist - see
+ *                {@code IdempotencyProperties.Filter#getReplayHeaders()}
+ * @param body    the raw response body, Base64-encoded
+ */
+public record CapturedResponse(int status, Map<String, List<String>> headers, String body) {
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/FilterKeyComposer.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/FilterKeyComposer.java
@@ -1,0 +1,29 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import io.github.benhendayoussef.idempotency.internal.Hashing;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Storage-key composition for filter mode.
+ *
+ * <p>Produces byte-identical keys to the aspect-mode composer for the same request. That is not
+ * incidental: switching {@code idempotency.mode} must not orphan every key already in the store, and
+ * an application running both modes across a rolling deploy has to agree with itself about what a
+ * key means.
+ */
+final class FilterKeyComposer {
+
+    private FilterKeyComposer() {
+    }
+
+    static String compose(String clientKey, String namespace, HttpServletRequest request) {
+        // The mapping lookup this filter already performed populates BEST_MATCHING_PATTERN, so the
+        // route pattern is available here exactly as the aspect sees it later.
+        String route = Objects.toString(
+                request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE),
+                request.getRequestURI());
+        return Hashing.sha256Hex(namespace + '|' + request.getMethod() + '|' + route + '|' + clientKey);
+    }
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/IdempotencyFilter.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/filter/IdempotencyFilter.java
@@ -1,0 +1,299 @@
+package io.github.benhendayoussef.idempotency.internal.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * {@code idempotency.mode=filter}: claim, replay and completion at the HTTP layer, storing the
+ * response byte for byte.
+ *
+ * <h2>Why this cannot be done in the aspect</h2>
+ *
+ * <p>The aspect runs <em>inside</em> the handler invocation, and the response body does not exist
+ * yet when it returns - message conversion happens afterwards. So aspect mode stores the handler's
+ * return value and re-serializes it on replay, which is why it cannot capture anything written
+ * directly to the {@code HttpServletResponse}, a header added further down the chain, or a content
+ * type negotiated at write time. Capturing real bytes means owning the request from outside the
+ * whole dispatch, which is what a filter is.
+ *
+ * <p>The two modes are therefore mutually exclusive: when this filter is active the aspect is not
+ * registered at all. Running both would have each claim the same key for the same request.
+ *
+ * <h2>Deciding what to protect</h2>
+ *
+ * <p>Selection stays annotation-driven - {@code @Idempotent} on the handler method, exactly as in
+ * aspect mode - rather than becoming "every POST with a key header". Two modes of the same library
+ * disagreeing about <em>which</em> endpoints are idempotent would be a far worse surprise than any
+ * difference in how they store the response.
+ *
+ * <p>That requires knowing the handler before running it, so the request is resolved against the
+ * application's {@link HandlerMapping}s up front. Spring will resolve it again during the actual
+ * dispatch; the cost is one extra mapping lookup per request that carries an idempotency key.
+ */
+public class IdempotencyFilter extends OncePerRequestFilter implements Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyFilter.class);
+
+    /** Distinguishes a raw captured response from an aspect-mode serialized return value. */
+    public static final String RAW_PAYLOAD_TYPE = "!raw";
+
+    private final IdempotencyStore store;
+    private final IdempotencyProperties props;
+    private final ObjectMapper payloadMapper;
+    private final IdempotencyMetrics metrics;
+    private final List<HandlerMapping> handlerMappings;
+
+    public IdempotencyFilter(IdempotencyStore store, IdempotencyProperties props, ObjectMapper payloadMapper,
+            IdempotencyMetrics metrics, List<HandlerMapping> handlerMappings) {
+        this.store = store;
+        this.props = props;
+        this.payloadMapper = payloadMapper;
+        this.metrics = metrics;
+        this.handlerMappings = handlerMappings;
+    }
+
+    /**
+     * Runs late enough that Spring Security has already authenticated - a 401 must never claim a key
+     * on behalf of a caller who was then rejected - but still outside the dispatcher.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 100;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        Idempotent annotation = resolveAnnotation(request);
+        if (annotation == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String headerName = annotation.keyHeader().isBlank() ? props.getHeaderName() : annotation.keyHeader();
+        String clientKey = request.getHeader(headerName);
+        if (clientKey == null || clientKey.isBlank()) {
+            metrics.missingKey();
+            if (props.isRequireKey()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "Missing required " + headerName + " header");
+                return;
+            }
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String storeKey = FilterKeyComposer.compose(clientKey, "", request);
+        Duration ttl = annotation.ttl().isBlank() ? props.getDefaultTtl()
+                : Duration.parse("PT" + annotation.ttl());
+        // Argument fingerprinting is an aspect-mode feature: it hashes the resolved method arguments,
+        // which do not exist yet out here. The request body would be the equivalent, and reading it
+        // in a filter means buffering every request - a real cost imposed on every endpoint to serve
+        // one. Documented as a difference between the modes rather than silently approximated.
+        String fingerprint = "";
+
+        ClaimResult claim;
+        try {
+            claim = store.claim(storeKey, fingerprint, ttl);
+        } catch (RuntimeException e) {
+            metrics.storeFailure();
+            if (props.getOnStoreFailure() == IdempotencyProperties.OnStoreFailure.FAIL) {
+                response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "Idempotency store unavailable");
+                return;
+            }
+            log.warn("Idempotency store unavailable; executing unprotected per idempotency.on-store-failure", e);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (claim instanceof ClaimResult.AlreadyHeld held) {
+            handleExisting(request, response, chain, held.record(), storeKey);
+            return;
+        }
+        execute(request, response, chain, storeKey, ttl);
+    }
+
+    private void execute(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+            String storeKey, Duration ttl) throws ServletException, IOException {
+        ContentCachingResponseWrapper wrapper = new ContentCachingResponseWrapper(response);
+        boolean completed = false;
+        try {
+            chain.doFilter(request, wrapper);
+
+            CapturedResponse captured = capture(wrapper);
+            if (shouldRelease(captured.status())) {
+                store.release(storeKey);
+                metrics.released();
+            } else {
+                String json = payloadMapper.writeValueAsString(captured);
+                if (json.length() > props.getMaxPayloadSize().toBytes()) {
+                    store.release(storeKey);
+                    log.warn("Idempotent response for key {} exceeds idempotency.max-payload-size; not cached",
+                            storeKey);
+                } else {
+                    store.complete(storeKey, new IdempotencyRecord(State.COMPLETED, "", captured.status(),
+                            RAW_PAYLOAD_TYPE, json, Instant.now()), ttl);
+                }
+                metrics.executed();
+            }
+            completed = true;
+        } finally {
+            if (!completed) {
+                // The chain threw before a status was ever produced, so there is nothing to store and
+                // nothing to replay. Release rather than leaving the key IN_PROGRESS for its whole
+                // TTL, which would make every retry conflict against a request that never finished.
+                releaseQuietly(storeKey);
+            }
+            // Must happen on every path: the cached body is buffered and never reaches the client
+            // until it is copied out. Skipping this on the error path would turn a handler exception
+            // into an empty response.
+            wrapper.copyBodyToResponse();
+        }
+    }
+
+    private void handleExisting(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+            IdempotencyRecord record, String storeKey) throws ServletException, IOException {
+        if (record.state() == State.COMPLETED) {
+            metrics.replayed();
+            writeReplay(response, record, false);
+            return;
+        }
+        if (props.getOnConflict() == ConflictPolicy.FAIL_FAST) {
+            metrics.conflict();
+            sendConflict(response);
+            return;
+        }
+        Optional<IdempotencyRecord> finished = waitForCompletion(storeKey);
+        if (finished.isPresent()) {
+            metrics.replayedAfterWait();
+            writeReplay(response, finished.get(), true);
+            return;
+        }
+        metrics.waitTimeout();
+        sendConflict(response);
+    }
+
+    private Optional<IdempotencyRecord> waitForCompletion(String storeKey) {
+        Instant deadline = Instant.now().plus(props.getWaitTimeout());
+        while (Instant.now().isBefore(deadline)) {
+            Optional<IdempotencyRecord> found = store.find(storeKey);
+            if (found.isPresent() && found.get().state() == State.COMPLETED) {
+                return found;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Writes the stored response back exactly as it was sent, headers and bytes included. */
+    private void writeReplay(HttpServletResponse response, IdempotencyRecord record, boolean afterWait)
+            throws IOException {
+        CapturedResponse captured = payloadMapper.readValue(record.payload(), CapturedResponse.class);
+        response.setStatus(captured.status());
+        captured.headers().forEach((name, values) -> values.forEach(v -> response.addHeader(name, v)));
+        response.setHeader("Idempotent-Replay", "true");
+        byte[] body = Base64.getDecoder().decode(captured.body());
+        if (body.length > 0) {
+            // Content-Length is set explicitly rather than left to the container: the replayed body
+            // may differ in length from whatever a stale stored header claimed.
+            response.setContentLength(body.length);
+            response.getOutputStream().write(body);
+        }
+        response.flushBuffer();
+        if (afterWait) {
+            log.debug("Replayed idempotent response after waiting for the in-flight request");
+        }
+    }
+
+    private CapturedResponse capture(ContentCachingResponseWrapper wrapper) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        List<String> allowed = props.getFilter().getReplayHeaders();
+        for (String name : wrapper.getHeaderNames()) {
+            if (allowed.stream().anyMatch(a -> a.equalsIgnoreCase(name))) {
+                headers.put(name, new ArrayList<>(wrapper.getHeaders(name)));
+            }
+        }
+        String body = Base64.getEncoder().encodeToString(wrapper.getContentAsByteArray());
+        return new CapturedResponse(wrapper.getStatus(), headers, body);
+    }
+
+    private boolean shouldRelease(int status) {
+        return status >= 500 && props.getReleaseOn().contains(IdempotencyProperties.ReleaseOn.FIVE_XX);
+    }
+
+    private void sendConflict(HttpServletResponse response) throws IOException {
+        response.setHeader("Retry-After", String.valueOf(Math.max(1, props.getWaitTimeout().toSeconds())));
+        response.sendError(HttpServletResponse.SC_CONFLICT, "A request with this idempotency key is in progress");
+    }
+
+    private void releaseQuietly(String storeKey) {
+        try {
+            store.release(storeKey);
+        } catch (RuntimeException e) {
+            log.warn("Failed to release idempotency key {} after a failed request; it will expire with its TTL",
+                    storeKey, e);
+        }
+    }
+
+    /**
+     * Finds {@code @Idempotent} on the handler this request would dispatch to, without dispatching.
+     *
+     * <p>Returns null - meaning "not our business" - for anything unmapped, any non-handler-method
+     * target such as a static resource, and any exception during resolution. A filter that failed
+     * requests because it could not work out whether they were idempotent would be far worse than
+     * one that occasionally declines to protect a request.
+     */
+    private Idempotent resolveAnnotation(HttpServletRequest request) {
+        for (HandlerMapping mapping : handlerMappings) {
+            try {
+                HandlerExecutionChain chain = mapping.getHandler(request);
+                if (chain == null) {
+                    continue;
+                }
+                if (chain.getHandler() instanceof HandlerMethod handlerMethod) {
+                    return handlerMethod.getMethodAnnotation(Idempotent.class);
+                }
+                return null;
+            } catch (Exception e) {
+                log.debug("Handler resolution failed while checking for @Idempotent; "
+                        + "treating the request as not idempotent", e);
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,109 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.metrics.enabled",
+      "description": "Publish idempotency counters to Micrometer when a MeterRegistry is present. All outcomes land on one counter, idempotency.requests, tagged by outcome (executed, replayed, released, conflict, ...). Set false to keep the no-op implementation even in an application that has a registry."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
       ]
     }
   ]

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,126 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.jdbc.dialect",
+      "description": "Which SQL dialect the JDBC store speaks. AUTO asks the DataSource what database it is connected to, on first use rather than at startup. Set explicitly to skip detection."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
+      ]
+    },
+    {
+      "name": "idempotency.jdbc.dialect",
+      "values": [
+        {
+          "value": "auto",
+          "description": "Detect from the DataSource on first use."
+        },
+        {
+          "value": "postgres",
+          "description": "PostgreSQL."
+        },
+        {
+          "value": "mysql",
+          "description": "MySQL or MariaDB."
+        }
       ]
     }
   ]

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,126 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.mode",
+      "description": "How responses are captured and replayed. ASPECT stores the handler return value and re-serializes it on replay; FILTER stores the real HTTP response bytes, so a body written straight to the response and allowlisted headers replay exactly. Mutually exclusive - exactly one is registered."
+    },
+    {
+      "name": "idempotency.filter.replay-headers",
+      "description": "Response headers replayed verbatim in filter mode, by name. An allowlist: replaying Set-Cookie would hand a second caller the first caller session."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
+      ]
+    },
+    {
+      "name": "idempotency.mode",
+      "values": [
+        {
+          "value": "aspect",
+          "description": "Default. Captures the handler return value; cannot see anything written directly to the response."
+        },
+        {
+          "value": "filter",
+          "description": "Byte-exact replay of the real HTTP response. No argument fingerprinting."
+        }
       ]
     }
   ]

--- a/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/idempotency-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -75,54 +75,113 @@
     {
       "name": "idempotency.jdbc.join-transaction",
       "description": "Run the handler and the completion write in one shared transaction so they commit or roll back together (exactly-once), instead of committing separately (at-least-once). Off by default: it pulls handlers with no @Transactional of their own into a transaction, and a handler's own @Transactional(timeout) stops applying once it joins."
+    },
+    {
+      "name": "idempotency.caffeine.maximum-size",
+      "description": "Maximum entries the Caffeine store holds. Records normally leave by TTL; this is the backstop for when new keys arrive faster than old ones expire, so memory stays bounded. Least-recently-used entries are evicted first."
     }
   ],
   "hints": [
     {
       "name": "idempotency.store",
       "values": [
-        { "value": "auto", "description": "Redis if present on the classpath, otherwise fail startup unless overridden." },
-        { "value": "redis", "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis." },
-        { "value": "jdbc", "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource." },
-        { "value": "memory", "description": "Single-instance, non-durable. Local development and tests only." }
+        {
+          "value": "auto",
+          "description": "Redis if present on the classpath, otherwise fail startup unless overridden."
+        },
+        {
+          "value": "redis",
+          "description": "Fast, at-least-once. Requires spring-boot-starter-data-redis."
+        },
+        {
+          "value": "jdbc",
+          "description": "Durable, at-least-once by default; exactly-once with idempotency.jdbc.join-transaction=true. Requires a DataSource."
+        },
+        {
+          "value": "caffeine",
+          "description": "Single-instance, non-durable, with real TTL eviction and a bounded size. Requires idempotency-store-caffeine."
+        },
+        {
+          "value": "memory",
+          "description": "Single-instance, non-durable. Local development and tests only."
+        }
       ]
     },
     {
       "name": "idempotency.on-conflict",
       "values": [
-        { "value": "wait", "description": "Poll until the in-flight request completes, then replay its response." },
-        { "value": "fail_fast", "description": "Return 409 with Retry-After immediately." }
+        {
+          "value": "wait",
+          "description": "Poll until the in-flight request completes, then replay its response."
+        },
+        {
+          "value": "fail_fast",
+          "description": "Return 409 with Retry-After immediately."
+        }
       ]
     },
     {
       "name": "idempotency.on-store-failure",
       "values": [
-        { "value": "proceed", "description": "Execute the handler unprotected; log a WARN and increment a metric." },
-        { "value": "fail", "description": "Return 503 without executing the handler." }
+        {
+          "value": "proceed",
+          "description": "Execute the handler unprotected; log a WARN and increment a metric."
+        },
+        {
+          "value": "fail",
+          "description": "Return 503 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.scope",
       "values": [
-        { "value": "global", "description": "One namespace for every caller." },
-        { "value": "user", "description": "Namespaced per authenticated principal (requires Spring Security)." },
-        { "value": "tenant", "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)." },
-        { "value": "custom", "description": "Register your own ScopeResolver bean for CUSTOM." }
+        {
+          "value": "global",
+          "description": "One namespace for every caller."
+        },
+        {
+          "value": "user",
+          "description": "Namespaced per authenticated principal (requires Spring Security)."
+        },
+        {
+          "value": "tenant",
+          "description": "Namespaced per JWT tenant claim (idempotency.tenant-claim)."
+        },
+        {
+          "value": "custom",
+          "description": "Register your own ScopeResolver bean for CUSTOM."
+        }
       ]
     },
     {
       "name": "idempotency.on-missing-principal",
       "values": [
-        { "value": "global", "description": "Fall back to the global namespace; idempotency still works, just not per-caller." },
-        { "value": "skip", "description": "Execute the handler unprotected; log a DEBUG line and increment a metric." },
-        { "value": "reject", "description": "Return 400 without executing the handler." }
+        {
+          "value": "global",
+          "description": "Fall back to the global namespace; idempotency still works, just not per-caller."
+        },
+        {
+          "value": "skip",
+          "description": "Execute the handler unprotected; log a DEBUG line and increment a metric."
+        },
+        {
+          "value": "reject",
+          "description": "Return 400 without executing the handler."
+        }
       ]
     },
     {
       "name": "idempotency.release-on",
       "values": [
-        { "value": "five_xx", "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes." },
-        { "value": "timeout", "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request." }
+        {
+          "value": "five_xx",
+          "description": "Release the key when the handler throws a 5xx/infrastructure failure, so a retry re-executes."
+        },
+        {
+          "value": "timeout",
+          "description": "Release the key when a WAIT-policy duplicate times out waiting for the in-flight request."
+        }
       ]
     }
   ]

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
     testImplementation(project(":idempotency-store-jdbc"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
-    // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its
-    // own module; spring-boot-starter-test does not pull it in transitively.
-    testImplementation("org.springframework.boot:spring-boot-webmvc-test")
+    // No spring-boot-webmvc-test here on purpose: that module is Boot 4 only, and depending on it
+    // is what used to pin this suite to a single Boot generation. MockMvcTestConfiguration builds
+    // MockMvc from spring-test instead, which is identical on Boot 3 and 4.
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-data-redis")
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc")

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -14,9 +14,12 @@ dependencies {
 
     compileOnly("org.springframework.data:spring-data-redis")
     compileOnly("org.springframework:spring-jdbc")
+    // Optional: metrics are wired only when the application already has a MeterRegistry.
+    compileOnly("io.micrometer:micrometer-core")
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation("io.micrometer:micrometer-core")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:mysql")
+    testRuntimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.postgresql:postgresql")
 }
 

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 
     compileOnly("org.springframework.data:spring-data-redis")
     compileOnly("org.springframework:spring-jdbc")
+    // For HandlerMapping, referenced when wiring the filter-mode bean. Servlet MVC is
+    // always present at runtime under @ConditionalOnWebApplication(SERVLET), so compileOnly.
+    compileOnly("org.springframework:spring-webmvc")
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":idempotency-core"))
     compileOnly(project(":idempotency-store-redis"))
     compileOnly(project(":idempotency-store-jdbc"))
+    compileOnly(project(":idempotency-store-caffeine"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -17,6 +18,7 @@ dependencies {
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation(project(":idempotency-store-caffeine"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":idempotency-core"))
     compileOnly(project(":idempotency-store-redis"))
     compileOnly(project(":idempotency-store-jdbc"))
+    compileOnly(project(":idempotency-webflux"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -17,6 +18,8 @@ dependencies {
 
     testImplementation(project(":idempotency-store-redis"))
     testImplementation(project(":idempotency-store-jdbc"))
+    testImplementation(project(":idempotency-webflux"))
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     // Spring Boot 4 split @AutoConfigureMockMvc out of spring-boot-test-autoconfigure into its

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -32,6 +32,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -56,9 +57,29 @@ import org.springframework.transaction.PlatformTransactionManager;
 // Referenced by name, not by class literal: both are optional (compileOnly) and may not be on
 // the classpath at all, unlike a hard `after = {Foo.class}` this doesn't fail attribute
 // introspection when the referenced autoconfiguration is absent.
+//
+// Both Boot generations are listed because Boot 4 moved these autoconfigurations into per-module
+// packages. Naming only one generation would not fail on the other - it would silently match
+// nothing, so the store beans could be evaluated before the DataSource or StringRedisTemplate they
+// depend on exists. A name matching nothing is simply ignored, which is what makes listing all four
+// safe on both. See IdempotencyAutoConfigurationOrderingTest.
 @AutoConfiguration(afterName = {
+        // Spring Boot 4.x
         "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration",
-        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+        // Spring Boot 3.x
+        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration",
+        "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+        // Jackson, both generations. Not about bean availability like the four above - this one
+        // decides who owns the application-wide ObjectMapper. idempotencyPayloadObjectMapper is a
+        // bean of type ObjectMapper, and Spring Boot declares its own @Primary one behind
+        // @ConditionalOnMissingBean. Register ours first and Boot backs off entirely, so the
+        // starter-internal mapper silently becomes the mapper the application serializes every HTTP
+        // response with - and any IdempotencyObjectMapperCustomizer leaks into the app's own wire
+        // format. Ordering after Jackson means Boot's @Primary mapper always wins for the
+        // application and ours stays private to replay storage.
+        "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
+        "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration"
 })
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.SERVLET)
@@ -142,7 +163,8 @@ public class IdempotencyAutoConfiguration {
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,
-            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics,
+            @Qualifier("idempotencyPayloadObjectMapper") ObjectMapper idempotencyPayloadObjectMapper,
+            IdempotencyMetrics metrics,
             ObjectProvider<TransactionRunner> transactionRunner) {
         TransactionRunner runner = transactionRunner.getIfAvailable();
         if (runner == null && props.getJdbc().isJoinTransaction()) {
@@ -176,7 +198,8 @@ public class IdempotencyAutoConfiguration {
         @ConditionalOnMissingBean(IdempotencyStore.class)
         @ConditionalOnBean(StringRedisTemplate.class)
         IdempotencyStore redisIdempotencyStore(StringRedisTemplate redisTemplate,
-                ObjectMapper idempotencyPayloadObjectMapper, IdempotencyProperties props) {
+                @Qualifier("idempotencyPayloadObjectMapper") ObjectMapper idempotencyPayloadObjectMapper,
+                IdempotencyProperties props) {
             return new RedisIdempotencyStore(redisTemplate, idempotencyPayloadObjectMapper,
                     props.getRedis().getKeyPrefix());
         }

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.internal.scope.GlobalScopeResolver;
 import io.github.benhendayoussef.idempotency.internal.scope.PrincipalScopeResolver;
 import io.github.benhendayoussef.idempotency.internal.scope.TenantScopeResolver;
+import io.github.benhendayoussef.idempotency.store.caffeine.internal.CaffeineIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencyRecordSweeper;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySweeperScheduler;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
@@ -232,6 +233,21 @@ public class IdempotencyAutoConfiguration {
                         + "idempotency.jdbc.join-transaction=false to keep the at-least-once default.");
             }
             return new JdbcTransactionRunner(manager);
+        }
+    }
+
+    // Guards on the store class too, not just the property: idempotency-store-caffeine is optional
+    // (compileOnly here), so a user who set store=caffeine without adding the dependency must fall
+    // through to the fallback autoconfiguration and get its actionable message, not a NoClassDefFound.
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(CaffeineIdempotencyStore.class)
+    @ConditionalOnProperty(prefix = "idempotency", name = "store", havingValue = "caffeine")
+    static class CaffeineStoreConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(IdempotencyStore.class)
+        IdempotencyStore caffeineIdempotencyStore(IdempotencyProperties props) {
+            return new CaffeineIdempotencyStore(props.getCaffeine().getMaximumSize());
         }
     }
 

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -15,6 +15,7 @@ import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyExceptionHandler;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyKeyComposer;
 import io.github.benhendayoussef.idempotency.internal.InMemoryIdempotencyStore;
+import io.github.benhendayoussef.idempotency.internal.filter.IdempotencyFilter;
 import io.github.benhendayoussef.idempotency.internal.NoOpIdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.internal.scope.GlobalScopeResolver;
@@ -45,6 +46,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -137,8 +139,11 @@ public class IdempotencyAutoConfiguration {
         return map;
     }
 
+    // ASPECT is the default, and matchIfMissing keeps an application that never set idempotency.mode
+    // on exactly the behaviour it had before the property existed.
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "idempotency", name = "mode", havingValue = "aspect", matchIfMissing = true)
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,
@@ -156,6 +161,22 @@ public class IdempotencyAutoConfiguration {
         }
         return new IdempotencyAspect(store, props, fingerprinter, composer, scopes,
                 idempotencyPayloadObjectMapper, metrics, runner);
+    }
+
+    /**
+     * Filter mode. Mutually exclusive with the aspect above by property value, so exactly one of the
+     * two is ever registered - running both would have each claim the same key for the same request.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "idempotency", name = "mode", havingValue = "filter")
+    public IdempotencyFilter idempotencyFilter(IdempotencyStore store, IdempotencyProperties props,
+            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics,
+            ObjectProvider<HandlerMapping> handlerMappings) {
+        // ObjectProvider, not a direct List injection: the filter is created while the mapping beans
+        // are still being built, and demanding them eagerly here deadlocks context startup.
+        return new IdempotencyFilter(store, props, idempotencyPayloadObjectMapper, metrics,
+                handlerMappings.orderedStream().toList());
     }
 
     @Bean

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -22,7 +22,12 @@ import io.github.benhendayoussef.idempotency.internal.scope.PrincipalScopeResolv
 import io.github.benhendayoussef.idempotency.internal.scope.TenantScopeResolver;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencyRecordSweeper;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySweeperScheduler;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.LazySqlDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.MySqlDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.PostgresDialect;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.SqlDialectResolver;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcTransactionRunner;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.util.EnumMap;
@@ -188,10 +193,27 @@ public class IdempotencyAutoConfiguration {
     static class JdbcStoreConfiguration {
 
         @Bean
+        @ConditionalOnMissingBean(IdempotencySqlDialect.class)
+        @ConditionalOnBean(DataSource.class)
+        IdempotencySqlDialect idempotencySqlDialect(DataSource dataSource, IdempotencyProperties props) {
+            return switch (props.getJdbc().getDialect()) {
+                case POSTGRES -> new PostgresDialect();
+                case MYSQL -> new MySqlDialect();
+                // Detection opens one connection at startup. That is a deliberate trade: the
+                // alternative is discovering the wrong SQL was chosen from a duplicate execution
+                // in production, which is untraceable back to here.
+                case AUTO -> new LazySqlDialect(dataSource);
+            };
+        }
+
+        @Bean
         @ConditionalOnMissingBean(IdempotencyStore.class)
         @ConditionalOnBean(DataSource.class)
-        IdempotencyStore jdbcIdempotencyStore(DataSource dataSource, IdempotencyProperties props) {
-            return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), props.getJdbc().getTableName());
+        IdempotencyStore jdbcIdempotencyStore(DataSource dataSource, IdempotencyProperties props,
+                IdempotencySqlDialect dialect) {
+            log.debug("Idempotency JDBC store using the {} dialect", dialect.name());
+            return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource),
+                    props.getJdbc().getTableName(), dialect);
         }
 
         @Bean

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfiguration.java
@@ -61,7 +61,11 @@ import org.springframework.transaction.PlatformTransactionManager;
         "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
 })
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
-@ConditionalOnWebApplication(type = Type.SERVLET)
+// Any web application, not just servlet. Everything in this class except the aspect itself - store
+// selection, the payload mapper, fingerprinting, metrics, scope resolvers - is stack-agnostic, and
+// gating the whole class on SERVLET left a WebFlux application with no store at all. Only the
+// servlet aspect is servlet-specific, so only it carries the narrower condition.
+@ConditionalOnWebApplication
 @EnableConfigurationProperties(IdempotencyProperties.class)
 public class IdempotencyAutoConfiguration {
 
@@ -139,6 +143,7 @@ public class IdempotencyAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnWebApplication(type = Type.SERVLET)
     public IdempotencyAspect idempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
             ArgumentFingerprinter fingerprinter, IdempotencyKeyComposer composer,
             Map<IdempotencyScope, ScopeResolver> scopes,

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyMetricsAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyMetricsAutoConfiguration.java
@@ -1,0 +1,39 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Wires {@link IdempotencyMetrics} to Micrometer when the application already has a
+ * {@code MeterRegistry}. Nothing to configure: adding {@code spring-boot-starter-actuator} (or any
+ * other source of a registry) is the whole opt-in.
+ *
+ * <p>This is a separate autoconfiguration class rather than a nested one inside
+ * {@link IdempotencyAutoConfiguration} because of ordering. That class contributes the no-op
+ * fallback behind {@code @ConditionalOnMissingBean}, and a nested member class is processed
+ * <em>after</em> its enclosing class's {@code @Bean} methods - the no-op would win the race and the
+ * Micrometer implementation would never be registered. Declaring {@code before} makes the ordering
+ * explicit and load-bearing rather than incidental.
+ *
+ * <p>{@code @ConditionalOnBean(MeterRegistry.class)} and not merely {@code @ConditionalOnClass}:
+ * Micrometer is on the classpath of plenty of applications that never expose a registry, and
+ * injecting one that does not exist would fail startup for something entirely optional.
+ */
+@AutoConfiguration(before = IdempotencyAutoConfiguration.class)
+@ConditionalOnClass(MeterRegistry.class)
+@ConditionalOnProperty(prefix = "idempotency.metrics", name = "enabled", matchIfMissing = true)
+public class IdempotencyMetricsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry.class)
+    @ConditionalOnMissingBean(IdempotencyMetrics.class)
+    public IdempotencyMetrics micrometerIdempotencyMetrics(MeterRegistry registry) {
+        return new MicrometerIdempotencyMetrics(registry);
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyStoreFallbackAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyStoreFallbackAutoConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -16,7 +15,9 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration(after = IdempotencyAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
-@ConditionalOnWebApplication(type = Type.SERVLET)
+// Any web application: a WebFlux app with no usable store needs the same actionable startup
+// failure a servlet one gets, rather than a NoSuchBeanDefinitionException from the aspect.
+@ConditionalOnWebApplication
 public class IdempotencyStoreFallbackAutoConfiguration {
 
     @Bean

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyWebFluxAutoConfiguration.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyWebFluxAutoConfiguration.java
@@ -1,0 +1,64 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import io.github.benhendayoussef.idempotency.internal.ArgumentFingerprinter;
+import io.github.benhendayoussef.idempotency.webflux.internal.IdempotencyExchangeContextFilter;
+import io.github.benhendayoussef.idempotency.webflux.internal.ReactiveIdempotencyAspect;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configures {@code @Idempotent} for WebFlux applications.
+ *
+ * <p>Mutually exclusive with {@link IdempotencyAutoConfiguration} by construction: that one is
+ * {@code @ConditionalOnWebApplication(SERVLET)} and this one is {@code REACTIVE}, so an application
+ * gets exactly one aspect and never both. That matters because the two would otherwise each claim
+ * the same key for the same request.
+ */
+@AutoConfiguration
+@ConditionalOnClass(ReactiveIdempotencyAspect.class)
+@ConditionalOnWebApplication(type = Type.REACTIVE)
+@ConditionalOnProperty(prefix = "idempotency", name = "enabled", matchIfMissing = true)
+@EnableConfigurationProperties(IdempotencyProperties.class)
+public class IdempotencyWebFluxAutoConfiguration {
+
+    /**
+     * Fails startup rather than silently ignoring a scope it cannot honour.
+     *
+     * <p>{@code USER} and {@code TENANT} resolve the principal from {@code SecurityContextHolder},
+     * a ThreadLocal with no meaning on a reactive stack - the reactive equivalent lives in the
+     * Reactor context and needs a different resolver SPI. Until that exists, an application that
+     * configured per-user scoping and quietly got global scoping instead would be sharing
+     * idempotency keys across users, which is a security problem, not a missing feature.
+     */
+    @Bean
+    public ReactiveIdempotencyAspect reactiveIdempotencyAspect(IdempotencyStore store,
+            IdempotencyProperties props, ArgumentFingerprinter fingerprinter,
+            ObjectMapper idempotencyPayloadObjectMapper, IdempotencyMetrics metrics) {
+        if (props.getScope() != IdempotencyScope.GLOBAL) {
+            throw new IllegalStateException(
+                    "idempotency.scope=" + props.getScope().name().toLowerCase()
+                    + " is not supported on WebFlux yet - only GLOBAL is. USER and TENANT resolve the "
+                    + "principal from SecurityContextHolder, which has no meaning on a reactive stack. "
+                    + "Falling back to GLOBAL silently would share idempotency keys across users, so "
+                    + "this fails instead. Set idempotency.scope=global, or use the servlet stack.");
+        }
+        return new ReactiveIdempotencyAspect(store, props, fingerprinter, idempotencyPayloadObjectMapper, metrics);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IdempotencyExchangeContextFilter idempotencyExchangeContextFilter() {
+        return new IdempotencyExchangeContextFilter();
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/MicrometerIdempotencyMetrics.java
+++ b/idempotency-spring-boot-starter/src/main/java/io/github/benhendayoussef/idempotency/autoconfigure/MicrometerIdempotencyMetrics.java
@@ -1,0 +1,109 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer-backed {@link IdempotencyMetrics}, registered automatically when Micrometer and a
+ * {@code MeterRegistry} are both present.
+ *
+ * <p>Everything is recorded on <strong>one</strong> counter, {@code idempotency.requests},
+ * distinguished by an {@code outcome} tag rather than by ten separate meter names. That is the
+ * difference between being able to ask "what fraction of requests were replays?" as a single ratio
+ * and having to hard-code a list of metric names into every dashboard. It also means a new outcome
+ * added later shows up in existing queries instead of being invisible until someone updates them.
+ *
+ * <p>Package-private on purpose: this adds no public API. An application that wants different
+ * meters registers its own {@link IdempotencyMetrics} bean, which the starter backs off from.
+ */
+final class MicrometerIdempotencyMetrics implements IdempotencyMetrics {
+
+    private static final String COUNTER = "idempotency.requests";
+    private static final String DESCRIPTION =
+            "Requests handled by @Idempotent, tagged by what the aspect did with them";
+
+    // Resolved once, not per call. registry.counter(name, tags) is a map lookup plus tag-list
+    // construction on every invocation, and these sit on the request hot path - the aspect calls one
+    // of them for every single request it advises.
+    private final Counter executed;
+    private final Counter replayed;
+    private final Counter replayedAfterWait;
+    private final Counter released;
+    private final Counter conflict;
+    private final Counter waitTimeout;
+    private final Counter fingerprintMismatch;
+    private final Counter missingKey;
+    private final Counter storeFailure;
+    private final Counter principalMissing;
+
+    MicrometerIdempotencyMetrics(MeterRegistry registry) {
+        this.executed = counter(registry, "executed");
+        this.replayed = counter(registry, "replayed");
+        this.replayedAfterWait = counter(registry, "replayed_after_wait");
+        this.released = counter(registry, "released");
+        this.conflict = counter(registry, "conflict");
+        this.waitTimeout = counter(registry, "wait_timeout");
+        this.fingerprintMismatch = counter(registry, "fingerprint_mismatch");
+        this.missingKey = counter(registry, "missing_key");
+        this.storeFailure = counter(registry, "store_failure");
+        this.principalMissing = counter(registry, "principal_missing");
+    }
+
+    private static Counter counter(MeterRegistry registry, String outcome) {
+        return Counter.builder(COUNTER)
+                .description(DESCRIPTION)
+                .tag("outcome", outcome)
+                .register(registry);
+    }
+
+    @Override
+    public void executed() {
+        executed.increment();
+    }
+
+    @Override
+    public void replayed() {
+        replayed.increment();
+    }
+
+    @Override
+    public void replayedAfterWait() {
+        replayedAfterWait.increment();
+    }
+
+    @Override
+    public void released() {
+        released.increment();
+    }
+
+    @Override
+    public void conflict() {
+        conflict.increment();
+    }
+
+    @Override
+    public void waitTimeout() {
+        waitTimeout.increment();
+    }
+
+    @Override
+    public void fingerprintMismatch() {
+        fingerprintMismatch.increment();
+    }
+
+    @Override
+    public void missingKey() {
+        missingKey.increment();
+    }
+
+    @Override
+    public void storeFailure() {
+        storeFailure.increment();
+    }
+
+    @Override
+    public void principalMissing() {
+        principalMissing.increment();
+    }
+}

--- a/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration
+io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyWebFluxAutoConfiguration

--- a/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration
 io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration
+io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyMetricsAutoConfiguration

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationOrderingTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationOrderingTest.java
@@ -1,0 +1,78 @@
+package io.github.benhendayoussef.idempotency.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+
+/**
+ * Guards the {@code afterName} ordering that makes the starter work on both Spring Boot generations.
+ *
+ * <p>{@link IdempotencyAutoConfiguration} must be applied <em>after</em> the autoconfigurations that
+ * supply a {@code DataSource} or a {@code StringRedisTemplate}, or its {@code @ConditionalOnBean}
+ * store beans can be evaluated before those beans exist and silently back off - leaving an
+ * application with no store and a startup failure that points at the wrong thing.
+ *
+ * <p>Boot 4 moved both of those autoconfigurations into per-module packages, so the names differ
+ * between generations. The failure mode this test exists for is nasty precisely because it is
+ * <strong>silent</strong>: an {@code afterName} entry that matches no class is simply ignored, so
+ * naming only one generation still starts up, still passes most tests, and only misbehaves on the
+ * other generation under the specific bean-timing that ordering exists to prevent. Nothing about
+ * that failure is visible at compile time, which is why it is asserted here by name.
+ */
+class IdempotencyAutoConfigurationOrderingTest {
+
+    private static final String BOOT4_REDIS =
+            "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration";
+    private static final String BOOT4_JDBC =
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration";
+    private static final String BOOT3_REDIS =
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration";
+    private static final String BOOT3_JDBC =
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration";
+
+    private List<String> afterNames() {
+        AutoConfiguration ann = AnnotatedElementUtils.findMergedAnnotation(
+                IdempotencyAutoConfiguration.class, AutoConfiguration.class);
+        assertThat(ann).as("IdempotencyAutoConfiguration must be an @AutoConfiguration").isNotNull();
+        return Arrays.asList(ann.afterName());
+    }
+
+    @Test
+    void ordersItselfAfterBothGenerationsOfTheStoreAutoConfigurations() {
+        assertThat(afterNames())
+                .as("dropping any of these silently disables ordering on that Boot generation")
+                .contains(BOOT4_REDIS, BOOT4_JDBC, BOOT3_REDIS, BOOT3_JDBC);
+    }
+
+    /**
+     * Whichever generation is actually on the test classpath, at least one Redis and one JDBC name
+     * must resolve to a real class. This is what would catch a typo or an upstream rename - the
+     * assertion above only proves the strings are present, not that they mean anything.
+     */
+    @Test
+    void atLeastOneNamedAutoConfigurationResolvesOnTheActiveClasspath() {
+        assertThat(resolvable(BOOT4_REDIS, BOOT3_REDIS))
+                .as("no Redis autoconfiguration name matched a real class - the afterName entries are "
+                        + "either misspelled or the upstream class moved again")
+                .isTrue();
+        assertThat(resolvable(BOOT4_JDBC, BOOT3_JDBC))
+                .as("no DataSource autoconfiguration name matched a real class")
+                .isTrue();
+    }
+
+    private static boolean resolvable(String... candidates) {
+        for (String fqn : candidates) {
+            try {
+                Class.forName(fqn);
+                return true;
+            } catch (ClassNotFoundException ignored) {
+                // Wrong generation for this classpath - try the next.
+            }
+        }
+        return false;
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -22,7 +22,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -178,7 +177,7 @@ class IdempotencyAutoConfigurationTest {
         // StringRedisTemplate as long as a RedisConnectionFactory exists - verified here against
         // the real autoconfiguration, not a hand-rolled stand-in.
         new WebApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(DataRedisAutoConfiguration.class,
+                .withConfiguration(AutoConfigurations.of(springRedisAutoConfiguration(),
                         IdempotencyAutoConfiguration.class, IdempotencyStoreFallbackAutoConfiguration.class))
                 .withUserConfiguration(RedisConnectionFactoryOnlyConfiguration.class, CustomNonStringRedisTemplateConfiguration.class)
                 .run(ctx -> {
@@ -393,5 +392,25 @@ class IdempotencyAutoConfigurationTest {
             template.afterPropertiesSet();
             return template;
         }
+    }
+
+    /**
+     * Boot 4 renamed and repackaged Redis autoconfiguration ({@code DataRedisAutoConfiguration}) from
+     * the Boot 3 {@code RedisAutoConfiguration}. This test needs the real one - the whole point is to
+     * verify against Spring Boot&#39;s own autoconfiguration rather than a hand-rolled stand-in - so it is
+     * resolved by name and whichever generation is on the classpath wins.
+     */
+    private static Class<?> springRedisAutoConfiguration() {
+        for (String fqn : List.of(
+                "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration",
+                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration")) {
+            try {
+                return Class.forName(fqn);
+            } catch (ClassNotFoundException ignored) {
+                // Wrong generation - try the next.
+            }
+        }
+        throw new IllegalStateException(
+                "Neither the Boot 3 nor the Boot 4 Redis autoconfiguration is on the test classpath");
     }
 }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -2,13 +2,17 @@ package io.github.benhendayoussef.idempotency.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
 import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
+import io.github.benhendayoussef.idempotency.internal.NoOpIdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -202,6 +206,61 @@ class IdempotencyAutoConfigurationTest {
                 });
     }
 
+    // --- Micrometer metrics wiring -----------------------------------------------------------
+
+    @Test
+    void noMeterRegistry_keepsTheNoOpMetrics() {
+        // Micrometer is on this test classpath but no registry bean exists - the common shape for an
+        // application that has the jar transitively and never configured actuator. Injecting a
+        // MeterRegistry here would fail startup over something entirely optional.
+        runner.withUserConfiguration(RedisTemplateConfiguration.class)
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(IdempotencyMetrics.class);
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .isInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void aMeterRegistryBeanSwitchesMetricsToMicrometer() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class)
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .as("the Micrometer implementation must win over the no-op fallback, which "
+                                    + "only works because IdempotencyMetricsAutoConfiguration is ordered before")
+                            .isNotInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void metricsCanBeDisabledEvenWithARegistryPresent() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class)
+                .withPropertyValues("idempotency.metrics.enabled=false")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencyMetrics.class))
+                            .isInstanceOf(NoOpIdempotencyMetrics.class);
+                });
+    }
+
+    @Test
+    void aUserSuppliedMetricsBeanStillWins() {
+        metricsRunner().withUserConfiguration(RedisTemplateConfiguration.class, MeterRegistryConfiguration.class,
+                        CustomMetricsConfiguration.class)
+                .run(ctx -> assertThat(ctx.getBean(IdempotencyMetrics.class))
+                        .isSameAs(CustomMetricsConfiguration.CUSTOM));
+    }
+
+    /** The default runner does not load the metrics autoconfiguration; these cases need it. */
+    private WebApplicationContextRunner metricsRunner() {
+        return new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(
+                IdempotencyMetricsAutoConfiguration.class,
+                IdempotencyAutoConfiguration.class,
+                IdempotencyStoreFallbackAutoConfiguration.class));
+    }
+
     // --- idempotency.jdbc.join-transaction wiring (C4/C5/C6) ---------------------------------
 
     @Test
@@ -289,7 +348,8 @@ class IdempotencyAutoConfigurationTest {
         }
         assertThat(lines).containsExactlyInAnyOrder(
                 "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration",
-                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration");
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration",
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyMetricsAutoConfiguration");
     }
 
     @Test
@@ -392,6 +452,25 @@ class IdempotencyAutoConfigurationTest {
             template.setConnectionFactory(factory);
             template.afterPropertiesSet();
             return template;
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MeterRegistryConfiguration {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomMetricsConfiguration {
+        static final IdempotencyMetrics CUSTOM = new IdempotencyMetrics() {
+        };
+
+        @Bean
+        IdempotencyMetrics idempotencyMetrics() {
+            return CUSTOM;
         }
     }
 }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -289,7 +289,8 @@ class IdempotencyAutoConfigurationTest {
         }
         assertThat(lines).containsExactlyInAnyOrder(
                 "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyAutoConfiguration",
-                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration");
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyStoreFallbackAutoConfiguration",
+                "io.github.benhendayoussef.idempotency.autoconfigure.IdempotencyWebFluxAutoConfiguration");
     }
 
     @Test

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.io.IOException;
@@ -199,6 +200,35 @@ class IdempotencyAutoConfigurationTest {
                     assertThat(props.getReleaseOn())
                             .containsExactlyInAnyOrder(IdempotencyProperties.ReleaseOn.FIVE_XX,
                                     IdempotencyProperties.ReleaseOn.TIMEOUT);
+                });
+    }
+
+    // --- SQL dialect selection ---------------------------------------------------------------
+
+    @Test
+    void dialectAutoDetectionDoesNotTouchTheDatabaseAtStartup() {
+        // DataSourceConfiguration points at a Postgres that is not running. Startup must still
+        // succeed: an unreachable database is a request-time condition that
+        // idempotency.on-store-failure decides what to do about, and detecting the dialect eagerly
+        // would promote it to a startup failure and take the application down instead.
+        runner.withUserConfiguration(DataSourceConfiguration.class)
+                .withPropertyValues("idempotency.store=jdbc")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(IdempotencySqlDialect.class);
+                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name())
+                            .as("resolving the name must not be what forces a connection either")
+                            .isEqualTo("auto (not yet resolved)");
+                });
+    }
+
+    @Test
+    void anExplicitDialectSkipsDetectionEntirely() {
+        runner.withUserConfiguration(DataSourceConfiguration.class)
+                .withPropertyValues("idempotency.store=jdbc", "idempotency.jdbc.dialect=mysql")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name()).isEqualTo("MySQL");
                 });
     }
 

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
 import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
 import io.github.benhendayoussef.idempotency.internal.TransactionRunner;
+import io.github.benhendayoussef.idempotency.store.caffeine.internal.CaffeineIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.jdbc.internal.JdbcIdempotencyStore;
 import io.github.benhendayoussef.idempotency.store.redis.internal.RedisIdempotencyStore;
 import java.io.IOException;
@@ -77,6 +78,30 @@ class IdempotencyAutoConfigurationTest {
                 .run(ctx -> {
                     assertThat(ctx).hasSingleBean(IdempotencyStore.class);
                     assertThat(ctx.getBean(IdempotencyStore.class)).isInstanceOf(JdbcIdempotencyStore.class);
+                });
+    }
+
+    @Test
+    void picksCaffeineWhenExplicitlyConfigured() {
+        runner.withPropertyValues("idempotency.store=caffeine")
+                .run(ctx -> {
+                    assertThat(ctx).hasSingleBean(IdempotencyStore.class);
+                    assertThat(ctx.getBean(IdempotencyStore.class))
+                            .isInstanceOf(CaffeineIdempotencyStore.class);
+                });
+    }
+
+    @Test
+    void caffeineWithoutTheModuleOnTheClasspathFailsWithTheActionableStoreMessage() {
+        // The module is optional. Asking for it without adding the dependency must produce the
+        // FailureAnalyzer message that names the problem, not a NoClassDefFoundError from a bean
+        // method that should never have been evaluated.
+        runner.withPropertyValues("idempotency.store=caffeine")
+                .withClassLoader(new FilteredClassLoader(CaffeineIdempotencyStore.class))
+                .run(ctx -> {
+                    assertThat(ctx).hasFailed();
+                    assertThat(ctx.getStartupFailure())
+                            .hasMessageContaining("No IdempotencyStore is configured");
                 });
     }
 

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/autoconfigure/IdempotencyAutoConfigurationTest.java
@@ -244,22 +244,6 @@ class IdempotencyAutoConfigurationTest {
                     assertThat(ctx).hasSingleBean(IdempotencyMetrics.class);
                     assertThat(ctx.getBean(IdempotencyMetrics.class))
                             .isInstanceOf(NoOpIdempotencyMetrics.class);
-    // --- SQL dialect selection ---------------------------------------------------------------
-
-    @Test
-    void dialectAutoDetectionDoesNotTouchTheDatabaseAtStartup() {
-        // DataSourceConfiguration points at a Postgres that is not running. Startup must still
-        // succeed: an unreachable database is a request-time condition that
-        // idempotency.on-store-failure decides what to do about, and detecting the dialect eagerly
-        // would promote it to a startup failure and take the application down instead.
-        runner.withUserConfiguration(DataSourceConfiguration.class)
-                .withPropertyValues("idempotency.store=jdbc")
-                .run(ctx -> {
-                    assertThat(ctx).hasNotFailed();
-                    assertThat(ctx).hasSingleBean(IdempotencySqlDialect.class);
-                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name())
-                            .as("resolving the name must not be what forces a connection either")
-                            .isEqualTo("auto (not yet resolved)");
                 });
     }
 
@@ -301,6 +285,27 @@ class IdempotencyAutoConfigurationTest {
                 IdempotencyAutoConfiguration.class,
                 IdempotencyStoreFallbackAutoConfiguration.class));
     }
+
+    // --- SQL dialect selection ---------------------------------------------------------------
+
+    @Test
+    void dialectAutoDetectionDoesNotTouchTheDatabaseAtStartup() {
+        // DataSourceConfiguration points at a Postgres that is not running. Startup must still
+        // succeed: an unreachable database is a request-time condition that
+        // idempotency.on-store-failure decides what to do about, and detecting the dialect eagerly
+        // would promote it to a startup failure and take the application down instead.
+        runner.withUserConfiguration(DataSourceConfiguration.class)
+                .withPropertyValues("idempotency.store=jdbc")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(IdempotencySqlDialect.class);
+                    assertThat(ctx.getBean(IdempotencySqlDialect.class).name())
+                            .as("resolving the name must not be what forces a connection either")
+                            .isEqualTo("auto (not yet resolved)");
+                });
+    }
+
+    @Test
     void anExplicitDialectSkipsDetectionEntirely() {
         runner.withUserConfiguration(DataSourceConfiguration.class)
                 .withPropertyValues("idempotency.store=jdbc", "idempotency.jdbc.dialect=mysql")
@@ -309,6 +314,7 @@ class IdempotencyAutoConfigurationTest {
                     assertThat(ctx.getBean(IdempotencySqlDialect.class).name()).isEqualTo("MySQL");
                 });
     }
+
     // --- idempotency.jdbc.join-transaction wiring (C4/C5/C6) ---------------------------------
 
     @Test

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/AbstractIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/AbstractIdempotencyBehaviorTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -55,7 +55,7 @@ import org.springframework.web.servlet.HandlerMapping;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
         classes = AbstractIdempotencyBehaviorTest.TestApp.class)
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 abstract class AbstractIdempotencyBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CaffeineIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CaffeineIdempotencyBehaviorTest.java
@@ -1,0 +1,19 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * The full behavioural matrix against the Caffeine store.
+ *
+ * <p>No container needed - the point of this store is that it runs in-process - but the matrix is
+ * still worth running in full rather than trusting the unit tests. The store's contract is defined
+ * by what the aspect does with it, and the semantics that matter most here (a claim being visible
+ * to a concurrent duplicate, expiry being observed on the boundary) are exercised far harder by the
+ * concurrency soak and the TTL cases than by direct calls.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = AbstractIdempotencyBehaviorTest.TestApp.class,
+        properties = {"idempotency.store=caffeine",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+class CaffeineIdempotencyBehaviorTest extends AbstractIdempotencyBehaviorTest {
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CustomJacksonModuleTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/CustomJacksonModuleTest.java
@@ -23,8 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
                 CustomJacksonModuleTest.PointModuleConfiguration.class},
         properties = {"idempotency.store=memory", "idempotency.scope=global",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class CustomJacksonModuleTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
         classes = FilterModeBehaviorTest.FilterApp.class,
         properties = {"idempotency.mode=filter", "idempotency.store=memory",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class FilterModeBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/FilterModeBehaviorTest.java
@@ -1,0 +1,313 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.internal.IdempotencyAspect;
+import io.github.benhendayoussef.idempotency.internal.filter.IdempotencyFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * {@code idempotency.mode=filter}: byte-exact replay.
+ *
+ * <p>The tests that matter here are the ones aspect mode <strong>cannot</strong> pass - a body
+ * written straight to the {@code HttpServletResponse}, and headers the handler set that are not part
+ * of any return value. Those are the documented reasons this mode exists, so proving replay works
+ * for an ordinary {@code ResponseEntity} would say almost nothing.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = FilterModeBehaviorTest.FilterApp.class,
+        properties = {"idempotency.mode=filter", "idempotency.store=memory",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+@AutoConfigureMockMvc
+class FilterModeBehaviorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RawController controller;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @BeforeEach
+    void reset() {
+        controller.reset();
+    }
+
+    /**
+     * The modes must never both be active: each would claim the same key for the same request, and
+     * the second would see the first one holding it.
+     */
+    @Test
+    void filterModeReplacesTheAspectRatherThanRunningAlongsideIt() {
+        assertThat(context.getBeanNamesForType(IdempotencyFilter.class)).hasSize(1);
+        assertThat(context.getBeanNamesForType(IdempotencyAspect.class))
+                .as("the aspect must be absent in filter mode")
+                .isEmpty();
+    }
+
+    /**
+     * The headline case. This handler writes bytes directly to the response and returns void, so
+     * there is no return value for aspect mode to capture - the README lists it as a limitation.
+     * Filter mode records the actual bytes, so the replay is identical.
+     */
+    @Test
+    void aBodyWrittenDirectlyToTheResponseIsReplayedByteForByte() throws Exception {
+        String key = "raw-" + System.nanoTime();
+
+        String first = mockMvc.perform(post("/f/raw").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        String replayed = mockMvc.perform(post("/f/raw").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Idempotent-Replay", "true"))
+                .andReturn().getResponse().getContentAsString();
+
+        assertThat(replayed).isEqualTo(first);
+        assertThat(first).isEqualTo("written-straight-to-the-response");
+        assertThat(controller.rawCount())
+                .as("the duplicate must be answered from the store, not re-executed")
+                .isEqualTo(1);
+    }
+
+    /** A header the handler set is part of the response, and must survive a replay. */
+    @Test
+    void headersOnTheAllowlistAreReplayed() throws Exception {
+        String key = "hdr-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/orders/42"));
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/orders/42"))
+                .andExpect(header().string("Idempotent-Replay", "true"));
+
+        assertThat(controller.createdCount()).isEqualTo(1);
+    }
+
+    /**
+     * The allowlist is a safety property, not a tuning knob. Replaying {@code Set-Cookie} would hand
+     * a second caller the first caller's session.
+     */
+    @Test
+    void headersOffTheAllowlistAreNotReplayed() throws Exception {
+        String key = "cookie-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/cookie").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", "SESSION=secret-for-caller-one"));
+
+        mockMvc.perform(post("/f/cookie").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Set-Cookie"));
+    }
+
+    @Test
+    void theStatusCodeIsReplayedExactly() throws Exception {
+        String key = "status-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/f/created").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void a5xxReleasesTheKeySoARetryReExecutes() throws Exception {
+        String key = "5xx-" + System.nanoTime();
+        controller.failNext();
+
+        mockMvc.perform(post("/f/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isInternalServerError());
+        mockMvc.perform(post("/f/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk());
+
+        assertThat(controller.flakyCount()).isEqualTo(2);
+    }
+
+    @Test
+    void a4xxIsKeptAndReplayed() throws Exception {
+        String key = "4xx-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/bad").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(post("/f/bad").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(controller.badCount())
+                .as("a deterministic client error is replayed, not re-executed")
+                .isEqualTo(1);
+    }
+
+    /** An endpoint without the annotation must be left completely alone, key header or not. */
+    @Test
+    void anUnannotatedEndpointIsUntouched() throws Exception {
+        String key = "plain-" + System.nanoTime();
+
+        mockMvc.perform(post("/f/plain").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Idempotent-Replay"));
+        mockMvc.perform(post("/f/plain").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isOk());
+
+        assertThat(controller.plainCount()).isEqualTo(2);
+    }
+
+    @Test
+    void aRequestWithNoKeyExecutesEveryTime() throws Exception {
+        mockMvc.perform(post("/f/created").contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/f/created").contentType("application/json").content("{}"))
+                .andExpect(status().isCreated());
+
+        assertThat(controller.createdCount()).isEqualTo(2);
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class FilterApp {
+        @Bean
+        RawController rawController() {
+            return new RawController();
+        }
+    }
+
+    @RestController
+    static class RawController {
+        private final AtomicInteger raw = new AtomicInteger();
+        private final AtomicInteger created = new AtomicInteger();
+        private final AtomicInteger cookie = new AtomicInteger();
+        private final AtomicInteger flaky = new AtomicInteger();
+        private final AtomicInteger bad = new AtomicInteger();
+        private final AtomicInteger plain = new AtomicInteger();
+        private final java.util.concurrent.atomic.AtomicBoolean failNext =
+                new java.util.concurrent.atomic.AtomicBoolean();
+
+        void reset() {
+            raw.set(0);
+            created.set(0);
+            cookie.set(0);
+            flaky.set(0);
+            bad.set(0);
+            plain.set(0);
+            failNext.set(false);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        int rawCount() {
+            return raw.get();
+        }
+
+        int createdCount() {
+            return created.get();
+        }
+
+        int flakyCount() {
+            return flaky.get();
+        }
+
+        int badCount() {
+            return bad.get();
+        }
+
+        int plainCount() {
+            return plain.get();
+        }
+
+        /** Writes to the response and returns void: nothing for aspect mode to capture. */
+        @Idempotent
+        @PostMapping("/f/raw")
+        void raw(@RequestBody Map<String, Object> body, HttpServletResponse response) throws IOException {
+            raw.incrementAndGet();
+            response.setStatus(HttpStatus.OK.value());
+            response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+            response.getOutputStream().write("written-straight-to-the-response".getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Idempotent
+        @PostMapping("/f/created")
+        ResponseEntity<Map<String, Object>> created(@RequestBody Map<String, Object> body) {
+            created.incrementAndGet();
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .header("Location", "/orders/42")
+                    .body(Map.of("id", 42));
+        }
+
+        @Idempotent
+        @PostMapping("/f/cookie")
+        ResponseEntity<Map<String, Object>> withCookie(@RequestBody Map<String, Object> body) {
+            cookie.incrementAndGet();
+            return ResponseEntity.ok()
+                    .header("Set-Cookie", "SESSION=secret-for-caller-one")
+                    .body(Map.of("ok", true));
+        }
+
+        @Idempotent
+        @PostMapping("/f/flaky")
+        ResponseEntity<Map<String, Object>> flaky(@RequestBody Map<String, Object> body) {
+            flaky.incrementAndGet();
+            if (failNext.compareAndSet(true, false)) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("err", true));
+            }
+            return ResponseEntity.ok(Map.of("ok", true));
+        }
+
+        @Idempotent
+        @PostMapping("/f/bad")
+        ResponseEntity<Map<String, Object>> bad(@RequestBody Map<String, Object> body) {
+            bad.incrementAndGet();
+            return ResponseEntity.badRequest().body(Map.of("err", "nope"));
+        }
+
+        @PostMapping("/f/plain")
+        ResponseEntity<Map<String, Object>> plain(@RequestBody Map<String, Object> body) {
+            plain.incrementAndGet();
+            return ResponseEntity.ok(Map.of("ok", true));
+        }
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/InMemoryStoreOverheadTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/InMemoryStoreOverheadTest.java
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
         classes = InMemoryStoreOverheadTest.TestApp.class,
         properties = {"idempotency.store=memory", "idempotency.scope=global",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class InMemoryStoreOverheadTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/JdbcStoreUnavailableBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/JdbcStoreUnavailableBehaviorTest.java
@@ -14,8 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
                 // SpringSecurityOrderingTest) - see TestAutoconfigExcludes.
                 TestAutoconfigExcludes.EXCLUDE_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class JdbcStoreUnavailableBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
@@ -9,9 +9,9 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
                 MicrometerMetricsBehaviorTest.MeterRegistryConfiguration.class},
         properties = {"idempotency.store=memory",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class MicrometerMetricsBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MicrometerMetricsBehaviorTest.java
@@ -1,0 +1,139 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * The counters must move for real requests through the real HTTP/AOP path, against a real
+ * {@link MeterRegistry} - not a mock. A metrics implementation that compiles but never increments
+ * is the classic way observability silently fails, and it fails quietly enough that nobody notices
+ * until they need a dashboard during an incident.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = {AbstractIdempotencyBehaviorTest.TestApp.class,
+                MicrometerMetricsBehaviorTest.MeterRegistryConfiguration.class},
+        properties = {"idempotency.store=memory",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY})
+@AutoConfigureMockMvc
+class MicrometerMetricsBehaviorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MeterRegistry registry;
+
+    @Autowired
+    private AbstractIdempotencyBehaviorTest.MatrixController controller;
+
+    private double count(String outcome) {
+        var counter = registry.find("idempotency.requests").tag("outcome", outcome).counter();
+        return counter == null ? 0d : counter.count();
+    }
+
+    @Test
+    void firstCallCountsAsExecutedAndTheDuplicateAsReplayed() throws Exception {
+        double executedBefore = count("executed");
+        double replayedBefore = count("replayed");
+        String key = "metrics-" + System.nanoTime();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(count("executed") - executedBefore).isEqualTo(1d);
+        assertThat(count("replayed") - replayedBefore).isZero();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(count("replayed") - replayedBefore)
+                .as("the duplicate is a replay, and must not also count as an execution").isEqualTo(1d);
+        assertThat(count("executed") - executedBefore).isEqualTo(1d);
+    }
+
+    @Test
+    void aRequestWithNoKeyCountsAsMissingKey() throws Exception {
+        double before = count("missing_key");
+        mockMvc.perform(post("/m/echo").contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+        assertThat(count("missing_key") - before).isEqualTo(1d);
+    }
+
+    @Test
+    void a5xxReleasesTheKeyAndCountsAsReleased() throws Exception {
+        double before = count("released");
+        String key = "metrics-released-" + System.nanoTime();
+
+        // /m/flaky throws a 500-mapped exception on the armed call, which the failure policy
+        // releases so a retry can re-execute.
+        controller.armFailNextInfra();
+
+        mockMvc.perform(post("/m/flaky").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isInternalServerError());
+
+        assertThat(count("released") - before).isEqualTo(1d);
+    }
+
+    @Test
+    void aDifferentBodyOnTheSameKeyCountsAsAFingerprintMismatch() throws Exception {
+        double before = count("fingerprint_mismatch");
+        String key = "metrics-fp-" + System.nanoTime();
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":999}"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(count("fingerprint_mismatch") - before).isEqualTo(1d);
+    }
+
+    /**
+     * Every outcome shares one meter name, so a dashboard can express "replay rate" as a ratio over
+     * a single series instead of hard-coding a list of metric names. Asserting the shape here means
+     * a future outcome added as its own meter name breaks this test rather than silently splitting
+     * the series.
+     */
+    @Test
+    void allOutcomesShareASingleCounterNameDistinguishedByTag() throws Exception {
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", "shape-" + System.nanoTime())
+                .contentType("application/json").content("{\"a\":1}"));
+
+        var meters = registry.find("idempotency.requests").counters();
+        assertThat(meters).isNotEmpty();
+        assertThat(meters)
+                .allSatisfy(c -> assertThat(c.getId().getTag("outcome"))
+                        .as("every idempotency.requests counter must carry an outcome tag")
+                        .isNotNull());
+        assertThat(registry.getMeters())
+                .filteredOn(m -> m.getId().getName().startsWith("idempotency."))
+                .allSatisfy(m -> assertThat(m.getId().getName())
+                        .as("no idempotency meter may use a name other than the single shared counter")
+                        .isEqualTo("idempotency.requests"));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MeterRegistryConfiguration {
+        // A real registry, not a mock: SimpleMeterRegistry actually accumulates values, so the
+        // assertions above test the counters rather than testing that a mock was called.
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MockMvcTestConfiguration.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MockMvcTestConfiguration.java
@@ -1,0 +1,42 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import jakarta.servlet.Filter;
+import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Supplies the {@link MockMvc} bean that {@code @AutoConfigureMockMvc} used to provide.
+ *
+ * <p>Boot 4 moved that annotation into its own {@code spring-boot-webmvc-test} module, which does
+ * not exist in Boot 3 - it was the <strong>single</strong> thing preventing this test suite from
+ * compiling against both generations. Building {@code MockMvc} by hand costs a few lines and
+ * removes the only version-specific dependency in the project, so the same sources run on Boot 3.x
+ * and 4.x with no source sets, no reflection, and no duplicated tests.
+ *
+ * <p>Everything here comes from {@code spring-test} and {@code jakarta.servlet}, both of which are
+ * identical across the two generations.
+ */
+@Configuration(proxyBeanMethods = false)
+class MockMvcTestConfiguration {
+
+    @Bean
+    MockMvc mockMvc(WebApplicationContext context, ObjectProvider<Filter> filters) {
+        var builder = MockMvcBuilders.webAppContextSetup(context);
+
+        // Registering the context's servlet filters is not incidental: SpringSecurityOrderingTest
+        // asserts that an unauthenticated request is rejected with 401 by the security filter chain
+        // *before* it ever reaches the dispatcher and the aspect. Without the filters attached that
+        // test would pass for the wrong reason - the request would sail through to the handler.
+        // orderedStream() honours @Order/Ordered, so the chain keeps its real relative ordering.
+        List<Filter> registered = filters.orderedStream().toList();
+        if (!registered.isEmpty()) {
+            builder.addFilters(registered.toArray(new Filter[0]));
+        }
+        return builder.build();
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
@@ -79,12 +79,11 @@ class MySqlIdempotencyBehaviorTest extends AbstractIdempotencyBehaviorTest {
 
     /**
      * The reclaim path, which is where the two dialects diverge most. Postgres expresses it as
-     * {@code ON CONFLICT ... WHERE expired}; MySQL has to push the condition into every assignment,
-     * and the update reports 2 affected rows rather than 1.
+     * {@code ON CONFLICT ... WHERE expired}; MySQL cannot, because its driver reports matched rather
+     * than changed rows, so it reclaims with a conditional UPDATE and falls back to an INSERT.
      *
-     * <p>A dialect that got the affected-row reading wrong would fail here specifically: the caller
-     * would be told the key is already held by a row it just wrote itself, and get a 409 instead of
-     * executing.
+     * <p>This is the test that fails if that fallback is wrong: the caller would be told the key is
+     * already held by a row it just wrote itself, and get a 409 instead of executing.
      */
     @Test
     void anExpiredRowIsReclaimedByTheNextClaimRatherThanConflicting() throws Exception {

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/MySqlIdempotencyBehaviorTest.java
@@ -1,0 +1,143 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.internal.IdempotencyKeyComposer;
+import io.github.benhendayoussef.idempotency.store.jdbc.internal.IdempotencySqlDialect;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The full behavioural matrix against a real MySQL, plus the dialect-specific cases below.
+ *
+ * <p>Running the whole inherited suite rather than a handful of smoke tests is the point: the
+ * differences between the two dialects are in claim semantics and expiry comparison, which is
+ * exactly what the matrix exercises hardest - concurrency, TTL, fingerprint mismatch, the failure
+ * policy. A MySQL-specific bug would show up as a wrong answer under one of those, not as a SQL
+ * syntax error.
+ */
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = AbstractIdempotencyBehaviorTest.TestApp.class,
+        properties = {
+                "idempotency.store=jdbc",
+                "spring.sql.init.mode=always",
+                "spring.sql.init.schema-locations=classpath:db/idempotency/mysql.sql",
+                TestAutoconfigExcludes.EXCLUDE_SECURITY
+        })
+class MySqlIdempotencyBehaviorTest extends AbstractIdempotencyBehaviorTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4");
+
+    @DynamicPropertySource
+    static void mysqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+    }
+
+    @Autowired
+    private IdempotencySqlDialect dialect;
+
+    @Autowired
+    private IdempotencyStore store;
+
+    @Autowired
+    private IdempotencyKeyComposer composer;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void autoDetectionPicksTheMySqlDialectWithoutBeingTold() throws Exception {
+        // idempotency.jdbc.dialect is left at AUTO above, so this asserts detection rather than
+        // configuration - the case every MySQL user actually hits.
+        //
+        // Detection is deferred until the store is first used; that laziness is asserted in
+        // IdempotencyAutoConfigurationTest, which can use a fresh context. Here the context is
+        // shared with the inherited suite, so the dialect may already be resolved - what this test
+        // proves is that detection reached the right answer against a real MySQL.
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", "detect-" + System.nanoTime())
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        assertThat(dialect.name()).isEqualTo("MySQL");
+    }
+
+    /**
+     * The reclaim path, which is where the two dialects diverge most. Postgres expresses it as
+     * {@code ON CONFLICT ... WHERE expired}; MySQL has to push the condition into every assignment,
+     * and the update reports 2 affected rows rather than 1.
+     *
+     * <p>A dialect that got the affected-row reading wrong would fail here specifically: the caller
+     * would be told the key is already held by a row it just wrote itself, and get a 409 instead of
+     * executing.
+     */
+    @Test
+    void anExpiredRowIsReclaimedByTheNextClaimRatherThanConflicting() throws Exception {
+        String key = "mysql-reclaim-" + System.nanoTime();
+        String storageKey = storageKeyFor(key);
+
+        var first = store.claim(storageKey, "fp", Duration.ofMillis(200));
+        assertThat(first).isInstanceOf(IdempotencyStore.ClaimResult.Acquired.class);
+
+        Thread.sleep(400);
+
+        var second = store.claim(storageKey, "fp", Duration.ofSeconds(30));
+        assertThat(second)
+                .as("the row had expired, so this claim must reclaim it - not report a conflict")
+                .isInstanceOf(IdempotencyStore.ClaimResult.Acquired.class);
+
+        assertThat(store.find(storageKey)).isPresent().get()
+                .extracting(io.github.benhendayoussef.idempotency.api.IdempotencyRecord::state)
+                .isEqualTo(State.IN_PROGRESS);
+    }
+
+    /**
+     * The other half of the same statement: a <em>live</em> row must be left completely untouched.
+     * MySQL applies the assignments left to right, so a guard ordering mistake would half-apply the
+     * reclaim here - wiping the stored payload of a record someone is about to replay - while still
+     * reporting a conflict, which no status-code assertion would catch.
+     */
+    @Test
+    void aLiveRecordIsNotModifiedByACompetingClaim() throws Exception {
+        String key = "mysql-live-" + System.nanoTime();
+        String storageKey = storageKeyFor(key);
+
+        mockMvc.perform(post("/m/echo").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"a\":1}"))
+                .andExpect(status().isCreated());
+
+        var before = store.find(storageKey).orElseThrow();
+        assertThat(before.state()).isEqualTo(State.COMPLETED);
+
+        // A competing claim on the same live key: must change nothing at all.
+        store.claim(storageKey, "different-fingerprint", Duration.ofSeconds(30));
+
+        var after = store.find(storageKey).orElseThrow();
+        assertThat(after.state()).as("a live COMPLETED record must survive a competing claim")
+                .isEqualTo(State.COMPLETED);
+        assertThat(after.fingerprint()).isEqualTo(before.fingerprint());
+        assertThat(after.payload()).isEqualTo(before.payload());
+        assertThat(after.status()).isEqualTo(before.status());
+    }
+
+    private String storageKeyFor(String clientKey) {
+        var request = new org.springframework.mock.web.MockHttpServletRequest("POST", "/m/echo");
+        request.setAttribute(org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/m/echo");
+        return composer.compose(clientKey, "", request);
+    }
+}

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/RedisStoreUnavailableBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/RedisStoreUnavailableBehaviorTest.java
@@ -14,8 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
                 // other tests in this module) - see TestAutoconfigExcludes.
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class RedisStoreUnavailableBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SlowStoreBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SlowStoreBehaviorTest.java
@@ -16,8 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
                 "spring.data.redis.connect-timeout=1s",
                 TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY
         })
-@AutoConfigureMockMvc
+@Import(MockMvcTestConfiguration.class)
 class SlowStoreBehaviorTest {
 
     private static ServerSocket wedgedServer;

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SpringSecurityOrderingTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/SpringSecurityOrderingTest.java
@@ -12,9 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -37,8 +37,9 @@ import org.springframework.web.bind.annotation.RestController;
         classes = {SpringSecurityOrderingTest.TestApp.class, SpringSecurityOrderingTest.SecurityConfig.class,
                 SpringSecurityOrderingTest.SecuredController.class},
         properties = {"idempotency.store=memory",
-                "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
-@AutoConfigureMockMvc
+                // Shared constant so this names both Boot generations - see TestAutoconfigExcludes.
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE})
+@Import(MockMvcTestConfiguration.class)
 class SpringSecurityOrderingTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
@@ -9,7 +9,7 @@ package io.github.benhendayoussef.idempotency.behavior;
  * tries to supply its own default (an unconfigured DataSource fails eagerly; a default security
  * filter chain requires authentication for every request) - neither of which the test wants.
  */
-final class TestAutoconfigExcludes {
+public final class TestAutoconfigExcludes {
 
     // Both generations are named. Boot ignores an exclude entry whose class is not on the
     // classpath, so the pair is safe on either - and naming only one would silently stop
@@ -27,13 +27,13 @@ final class TestAutoconfigExcludes {
             + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration";
 
     /** For tests that configure no DataSource of their own but do want default security. */
-    static final String EXCLUDE_DATASOURCE = "spring.autoconfigure.exclude=" + NO_DATASOURCE;
+    public static final String EXCLUDE_DATASOURCE = "spring.autoconfigure.exclude=" + NO_DATASOURCE;
 
     /** For JDBC-store tests: they need a real DataSource, just not Boot's default security. */
-    static final String EXCLUDE_SECURITY = "spring.autoconfigure.exclude=" + NO_SECURITY;
+    public static final String EXCLUDE_SECURITY = "spring.autoconfigure.exclude=" + NO_SECURITY;
 
     /** For Redis-store/in-memory-store tests: need neither a DataSource nor default security. */
-    static final String EXCLUDE_DATASOURCE_AND_SECURITY =
+    public static final String EXCLUDE_DATASOURCE_AND_SECURITY =
             "spring.autoconfigure.exclude=" + NO_DATASOURCE + "," + NO_SECURITY;
 
     private TestAutoconfigExcludes() {

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/TestAutoconfigExcludes.java
@@ -11,14 +11,23 @@ package io.github.benhendayoussef.idempotency.behavior;
  */
 final class TestAutoconfigExcludes {
 
+    // Both generations are named. Boot ignores an exclude entry whose class is not on the
+    // classpath, so the pair is safe on either - and naming only one would silently stop
+    // excluding anything on the other, letting Boot supply the very DataSource these tests
+    // exist to run without.
     private static final String NO_DATASOURCE =
-            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration";
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration";
     // Excludes only the autoconfiguration that installs Boot's default restrictive filter chain -
     // not the base SecurityAutoConfiguration, which also registers the SecurityProperties bean
     // other core Boot autoconfigurations (error handling) depend on regardless of whether a
     // security filter chain is wanted.
     private static final String NO_SECURITY =
-            "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration";
+            "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration,"
+            + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration";
+
+    /** For tests that configure no DataSource of their own but do want default security. */
+    static final String EXCLUDE_DATASOURCE = "spring.autoconfigure.exclude=" + NO_DATASOURCE;
 
     /** For JDBC-store tests: they need a real DataSource, just not Boot's default security. */
     static final String EXCLUDE_SECURITY = "spring.autoconfigure.exclude=" + NO_SECURITY;

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
@@ -3,6 +3,7 @@ package io.github.benhendayoussef.idempotency.webflux;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.behavior.TestAutoconfigExcludes;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,8 +43,10 @@ import reactor.core.publisher.Mono;
                 // be forced, or this would silently exercise the servlet aspect instead.
                 "spring.main.web-application-type=reactive",
                 // Likewise spring-boot-starter-jdbc: without this Boot tries to build a DataSource
-                // that this test never configures.
-                "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
+                // that this test never configures. Via the shared constant, which names both Boot
+                // generations - hardcoding the Boot 4 class here matched nothing on Boot 3, so every
+                // test in this class failed on a DataSource that should never have been created.
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE})
 class WebFluxIdempotencyBehaviorTest {
 
     @Autowired

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/webflux/WebFluxIdempotencyBehaviorTest.java
@@ -1,0 +1,315 @@
+package io.github.benhendayoussef.idempotency.webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+/**
+ * WebFlux behaviour through a real reactive stack, driven with {@link WebTestClient}.
+ *
+ * <p>These mirror the servlet matrix cases that genuinely differ here: the request is read from the
+ * Reactor context rather than a ThreadLocal, the store runs off the event loop, and the outcome is
+ * only known when the returned {@code Mono} completes. Every one of them could pass on the servlet
+ * side and fail on this one.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = WebFluxIdempotencyBehaviorTest.ReactiveApp.class,
+        properties = {"idempotency.store=memory", "idempotency.wait-timeout=3s",
+                // spring-boot-starter-web is on this module's test classpath for the servlet tests,
+                // and Boot prefers SERVLET whenever both stacks are present - so the web type has to
+                // be forced, or this would silently exercise the servlet aspect instead.
+                "spring.main.web-application-type=reactive",
+                // Likewise spring-boot-starter-jdbc: without this Boot tries to build a DataSource
+                // that this test never configures.
+                "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
+class WebFluxIdempotencyBehaviorTest {
+
+    @Autowired
+    private ReactiveController controller;
+
+    @Autowired
+    private ApplicationContext context;
+
+    private WebTestClient client;
+
+    @BeforeEach
+    void setUp() {
+        controller.reset();
+        client = WebTestClient.bindToApplicationContext(context).build()
+                .mutate().responseTimeout(Duration.ofSeconds(20)).build();
+    }
+
+    private WebTestClient.RequestHeadersSpec<?> post(String path, String key, String body) {
+        return client.post().uri(path)
+                .header("Idempotency-Key", key)
+                .header("Content-Type", "application/json")
+                .bodyValue(body);
+    }
+
+    @Test
+    void firstCallExecutesAndTheDuplicateReplaysWithoutReExecuting() {
+        String key = "wf-" + System.nanoTime();
+
+        post("/r/echo", key, "{\"a\":1}").exchange()
+                .expectStatus().isCreated()
+                .expectBody().jsonPath("$.a").isEqualTo(1);
+
+        post("/r/echo", key, "{\"a\":1}").exchange()
+                .expectStatus().isCreated()
+                .expectBody().jsonPath("$.a").isEqualTo(1);
+
+        assertThat(controller.echoCount()).as("the duplicate must be replayed, not re-executed").isEqualTo(1);
+    }
+
+    /**
+     * The case the operator chain has to lift explicitly. An empty {@code Mono} is a real response,
+     * and without turning that emptiness into a value the completion step never runs - leaving the
+     * key IN_PROGRESS until its TTL, so every later duplicate blocks or conflicts against a request
+     * that actually succeeded.
+     */
+    @Test
+    void aHandlerReturningAnEmptyMonoStillCompletesTheKey() {
+        String key = "wf-empty-" + System.nanoTime();
+
+        post("/r/empty", key, "{}").exchange().expectStatus().isOk();
+        post("/r/empty", key, "{}").exchange().expectStatus().isOk();
+
+        assertThat(controller.emptyCount())
+                .as("an empty response must be recorded as completed so the duplicate replays")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void sameKeyWithADifferentBodyIsRejectedRatherThanReplayed() {
+        String key = "wf-fp-" + System.nanoTime();
+
+        post("/r/echo", key, "{\"a\":1}").exchange().expectStatus().isCreated();
+        post("/r/echo", key, "{\"a\":999}").exchange()
+                // 422 by value: the enum constant was renamed to UNPROCESSABLE_CONTENT, and
+                // asserting on the constant makes this fail on one Spring version and pass on another.
+                .expectStatus().isEqualTo(422);
+
+        assertThat(controller.echoCount()).isEqualTo(1);
+    }
+
+    @Test
+    void a5xxReleasesTheKeySoARetryCanSucceed() {
+        String key = "wf-5xx-" + System.nanoTime();
+        controller.failNext();
+
+        post("/r/flaky", key, "{}").exchange().expectStatus().is5xxServerError();
+        post("/r/flaky", key, "{}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.flakyCount())
+                .as("a transient failure releases the key, so the retry re-executes")
+                .isEqualTo(2);
+    }
+
+    @Test
+    void a4xxIsKeptAndReplayedToTheRetry() {
+        String key = "wf-4xx-" + System.nanoTime();
+
+        post("/r/bad", key, "{}").exchange().expectStatus().isBadRequest();
+        // The replay must be a 400 too. It arrives as an ErrorResponse rather than a returned
+        // ResponseEntity - see ReactiveIdempotencyAspect.replay - which is what keeps the status
+        // intact regardless of what the handler declares it returns.
+        post("/r/bad", key, "{}").exchange().expectStatus().isBadRequest();
+
+        assertThat(controller.badCount())
+                .as("a deterministic client error is replayed, not re-executed")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void aRequestWithNoKeyPassesThroughAndExecutesEveryTime() {
+        client.post().uri("/r/echo").header("Content-Type", "application/json")
+                .bodyValue("{\"a\":1}").exchange().expectStatus().isCreated();
+        client.post().uri("/r/echo").header("Content-Type", "application/json")
+                .bodyValue("{\"a\":1}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.echoCount()).isEqualTo(2);
+    }
+
+    @Test
+    void aSlowHandlerStillReplaysItsResponseToALaterDuplicate() {
+        String key = "wf-slow-" + System.nanoTime();
+
+        post("/r/slow", key, "{}").exchange().expectStatus().isCreated();
+        post("/r/slow", key, "{}").exchange().expectStatus().isCreated();
+
+        assertThat(controller.slowCount()).isEqualTo(1);
+    }
+
+    /**
+     * Two duplicates genuinely in flight at once. The loser takes the WAIT path, which on this stack
+     * holds no thread while it waits - the delay is a timer, not a sleep. That removes the
+     * thread-pool exhaustion the servlet side documents as a limitation.
+     */
+    @Test
+    void twoConcurrentDuplicatesExecuteOnceAndBothGetTheSameResponse() {
+        String key = "wf-race-" + System.nanoTime();
+
+        Mono<Integer> a = sendForStatus("/r/slow", key);
+        Mono<Integer> b = sendForStatus("/r/slow", key);
+
+        var statuses = Mono.zip(a, b).block(Duration.ofSeconds(20));
+
+        assertThat(statuses).isNotNull();
+        assertThat(statuses.getT1()).isEqualTo(201);
+        assertThat(statuses.getT2()).isEqualTo(201);
+        assertThat(controller.slowCount())
+                .as("exactly one of the two concurrent duplicates may execute the handler")
+                .isEqualTo(1);
+    }
+
+    private Mono<Integer> sendForStatus(String path, String key) {
+        return Mono.fromCallable(() -> post(path, key, "{}").exchange()
+                        .returnResult(String.class).getStatus().value())
+                .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic());
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class ReactiveApp {
+        @Bean
+        ReactiveController reactiveController() {
+            return new ReactiveController();
+        }
+
+        /**
+         * spring-boot-starter-security is on this module's test classpath for the servlet security
+         * test, and WebFlux's default chain applies CSRF to every POST - which returned 403 for
+         * every request here, with nothing to do with idempotency. Declared explicitly rather than
+         * excluded by autoconfiguration class name, because that name differs between Boot
+         * generations and this suite has to run on both.
+         */
+        @Bean
+        SecurityWebFilterChain permitEverything(ServerHttpSecurity http) {
+            return http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+                    .authorizeExchange(ex -> ex.anyExchange().permitAll())
+                    .build();
+        }
+    }
+
+    @RestController
+    static class ReactiveController {
+        private final AtomicInteger echo = new AtomicInteger();
+        private final AtomicInteger empty = new AtomicInteger();
+        private final AtomicInteger flaky = new AtomicInteger();
+        private final AtomicInteger bad = new AtomicInteger();
+        private final AtomicInteger slow = new AtomicInteger();
+        private final AtomicBoolean failNext = new AtomicBoolean();
+
+        void reset() {
+            echo.set(0);
+            empty.set(0);
+            flaky.set(0);
+            bad.set(0);
+            slow.set(0);
+            failNext.set(false);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        int echoCount() {
+            return echo.get();
+        }
+
+        int emptyCount() {
+            return empty.get();
+        }
+
+        int flakyCount() {
+            return flaky.get();
+        }
+
+        int badCount() {
+            return bad.get();
+        }
+
+        int slowCount() {
+            return slow.get();
+        }
+
+        @Idempotent
+        @PostMapping("/r/echo")
+        Mono<ResponseEntity<Map<String, Object>>> echo(@RequestBody Map<String, Object> body) {
+            echo.incrementAndGet();
+            return Mono.just(ResponseEntity.status(HttpStatus.CREATED).body(body));
+        }
+
+        @Idempotent
+        @PostMapping("/r/empty")
+        Mono<Void> emptyResponse(@RequestBody Map<String, Object> body) {
+            empty.incrementAndGet();
+            return Mono.empty();
+        }
+
+        @Idempotent
+        @PostMapping("/r/flaky")
+        Mono<ResponseEntity<Map<String, Object>>> flaky(@RequestBody Map<String, Object> body) {
+            flaky.incrementAndGet();
+            if (failNext.compareAndSet(true, false)) {
+                return Mono.error(new InfrastructureException());
+            }
+            return Mono.just(ResponseEntity.status(HttpStatus.CREATED).body(Map.of("ok", true)));
+        }
+
+        @Idempotent
+        @PostMapping("/r/bad")
+        Mono<ResponseEntity<Map<String, Object>>> bad(@RequestBody Map<String, Object> body) {
+            bad.incrementAndGet();
+            return Mono.error(new ClientException());
+        }
+
+        @Idempotent
+        @PostMapping("/r/slow")
+        Mono<ResponseEntity<Map<String, Object>>> slow(@RequestBody Map<String, Object> body) {
+            slow.incrementAndGet();
+            return Mono.delay(Duration.ofMillis(400))
+                    .map(t -> ResponseEntity.status(HttpStatus.CREATED).body(Map.of("ok", true)));
+        }
+
+        // ResponseStatusException rather than a plain exception annotated @ResponseStatus.
+        // WebFlux maps this shape unconditionally, whereas annotation-driven status resolution
+        // depends on which error handler the application has configured - and when it is not in
+        // play everything becomes a default 500, which made the 5xx case below pass for entirely
+        // the wrong reason. These tests are about the failure policy (5xx releases, 4xx is kept
+        // and replayed), so the status has to be unambiguous.
+        static class InfrastructureException extends ResponseStatusException {
+            InfrastructureException() {
+                super(HttpStatus.INTERNAL_SERVER_ERROR, "boom");
+            }
+        }
+
+        static class ClientException extends ResponseStatusException {
+            ClientException() {
+                super(HttpStatus.BAD_REQUEST, "nope");
+            }
+        }
+    }
+}

--- a/idempotency-store-caffeine/build.gradle.kts
+++ b/idempotency-store-caffeine/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("java-library")
+}
+
+description = "Caffeine-backed idempotency store: single-instance, with real eviction and a bounded footprint."
+
+dependencies {
+    api(project(":idempotency-core"))
+    api("com.github.ben-manes.caffeine:caffeine")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/idempotency-store-caffeine/src/main/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStore.java
+++ b/idempotency-store-caffeine/src/main/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStore.java
@@ -1,0 +1,140 @@
+package io.github.benhendayoussef.idempotency.store.caffeine.internal;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Single-instance store with real eviction.
+ *
+ * <p>The built-in {@code InMemoryIdempotencyStore} is correct but unbounded: expired entries are
+ * <em>treated</em> as absent and never actually removed, so a long-running service accumulates one
+ * dead entry per idempotency key it has ever seen. That is fine for tests, which is what it was
+ * written for, and a slow leak in anything that stays up. This store keeps the same semantics and
+ * adds the two things that make it safe to leave running: per-entry expiry, so records go away when
+ * their TTL passes, and a maximum size, so memory has a ceiling even if traffic outruns expiry.
+ *
+ * <p>Still single-instance and still non-durable - state lives in local heap, so two application
+ * instances do not share it and a restart forgets everything. For anything replicated, use Redis or
+ * JDBC.
+ *
+ * <p>Public only because Spring auto-configuration in another module constructs it;
+ * <strong>not part of the supported API</strong>.
+ */
+public class CaffeineIdempotencyStore implements IdempotencyStore {
+
+    /**
+     * The expiry deadline is carried on the entry rather than being a fixed cache-wide duration,
+     * because TTL is per-record here: {@code @Idempotent(ttl = ...)} lets it vary per endpoint, and
+     * {@code complete()} re-stamps it.
+     */
+    private record Entry(IdempotencyRecord record, Instant expiresAt) {
+    }
+
+    private final Cache<String, Entry> cache;
+
+    public CaffeineIdempotencyStore(long maximumSize) {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfter(new Expiry<String, Entry>() {
+                    @Override
+                    public long expireAfterCreate(String key, Entry value, long currentTime) {
+                        return nanosUntil(value.expiresAt());
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(String key, Entry value, long currentTime,
+                            long currentDuration) {
+                        // Not currentDuration: complete() replaces an IN_PROGRESS entry with the
+                        // finished record and a fresh TTL, so keeping the remaining lifetime of the
+                        // claim would expire the stored response early - exactly when a replay needs
+                        // it most.
+                        return nanosUntil(value.expiresAt());
+                    }
+
+                    @Override
+                    public long expireAfterRead(String key, Entry value, long currentTime,
+                            long currentDuration) {
+                        // Reading must not extend the life of a record. Idempotency windows are
+                        // absolute: a key is valid for its TTL from when it was claimed, however
+                        // often it is replayed in the meantime.
+                        return currentDuration;
+                    }
+                })
+                .build();
+    }
+
+    private static long nanosUntil(Instant deadline) {
+        long nanos = Duration.between(Instant.now(), deadline).toNanos();
+        // Caffeine rejects a negative duration; an already-expired entry becomes immediately
+        // evictable instead.
+        return Math.max(nanos, 0L);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Atomic via {@code asMap().compute()}, which Caffeine performs under the entry's lock - the
+     * same guarantee {@code ConcurrentHashMap} gives, and the reason two concurrent duplicates
+     * cannot both be told they acquired the key.
+     *
+     * <p>The expiry check is still made explicitly here rather than relying on eviction. Eviction is
+     * asynchronous: an entry past its TTL can still be present for a short window, and treating it
+     * as live would mean a caller conflicts with a record that should already be gone.
+     */
+    @Override
+    public ClaimResult claim(String key, String fingerprint, Duration ttl) {
+        Instant now = Instant.now();
+        var candidate = new Entry(IdempotencyRecord.inProgress(fingerprint, now), now.plus(ttl));
+
+        Entry[] winner = new Entry[1];
+        cache.asMap().compute(key, (k, existing) -> {
+            if (existing == null || existing.expiresAt().isBefore(now)) {
+                winner[0] = candidate;
+                return candidate;
+            }
+            winner[0] = existing;
+            return existing;
+        });
+
+        if (winner[0] == candidate) {
+            return new ClaimResult.Acquired();
+        }
+        return new ClaimResult.AlreadyHeld(winner[0].record());
+    }
+
+    @Override
+    public void complete(String key, IdempotencyRecord record, Duration ttl) {
+        cache.put(key, new Entry(record, Instant.now().plus(ttl)));
+    }
+
+    @Override
+    public void release(String key) {
+        cache.invalidate(key);
+    }
+
+    @Override
+    public Optional<IdempotencyRecord> find(String key) {
+        Entry entry = cache.getIfPresent(key);
+        if (entry == null || entry.expiresAt().isBefore(Instant.now())) {
+            return Optional.empty();
+        }
+        return Optional.of(entry.record());
+    }
+
+    /** Entries currently held, after any pending eviction work. Exposed for tests and diagnostics. */
+    public long estimatedSize() {
+        cache.cleanUp();
+        return cache.estimatedSize();
+    }
+
+    /** Package-private hook so tests can assert eviction without sleeping for a real TTL. */
+    void runPendingEviction() {
+        cache.cleanUp();
+    }
+}

--- a/idempotency-store-caffeine/src/test/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStoreTest.java
+++ b/idempotency-store-caffeine/src/test/java/io/github/benhendayoussef/idempotency/store/caffeine/internal/CaffeineIdempotencyStoreTest.java
@@ -1,0 +1,149 @@
+package io.github.benhendayoussef.idempotency.store.caffeine.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The semantics have to match the other stores exactly - the aspect cannot tell them apart - so the
+ * interesting tests here are the two things this store adds over the built-in in-memory one:
+ * entries are actually evicted, and memory has a ceiling.
+ */
+class CaffeineIdempotencyStoreTest {
+
+    private final CaffeineIdempotencyStore store = new CaffeineIdempotencyStore(10_000);
+
+    @Test
+    void aFreshKeyIsAcquiredAndASecondClaimConflicts() {
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.AlreadyHeld.class);
+    }
+
+    @Test
+    void completeThenFindReturnsTheStoredRecord() {
+        store.claim("k", "fp", Duration.ofMinutes(5));
+        var record = new IdempotencyRecord(IdempotencyRecord.State.COMPLETED, "fp", 201,
+                "java.lang.String", "\"body\"", Instant.now());
+        store.complete("k", record, Duration.ofMinutes(5));
+
+        assertThat(store.find("k")).isPresent().get()
+                .extracting(IdempotencyRecord::payload).isEqualTo("\"body\"");
+    }
+
+    @Test
+    void releaseMakesTheKeyImmediatelyReclaimable() {
+        store.claim("k", "fp", Duration.ofMinutes(5));
+        store.release("k");
+
+        assertThat(store.find("k")).isEmpty();
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+    }
+
+    /**
+     * The reason this store exists. The built-in in-memory store treats an expired entry as absent
+     * but never removes it, so its map grows by one entry per key ever seen. Here the entry has to
+     * actually leave the cache.
+     */
+    @Test
+    void expiredEntriesAreEvictedRatherThanJustHidden() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            store.claim("short-" + i, "fp", Duration.ofMillis(100));
+        }
+        assertThat(store.estimatedSize()).isEqualTo(50);
+
+        // Well past the TTL, and deliberately so. Caffeine schedules variable expiry on a timer
+        // wheel whose finest bucket spans roughly a second, so eviction is not immediate at the
+        // moment a TTL passes - it happens on the next maintenance cycle after the wheel advances.
+        // A shorter wait here fails intermittently and would look like a bug in the store.
+        //
+        // That lag is exactly why claim() and find() still compare expiry themselves rather than
+        // trusting presence in the cache: an entry can outlive its TTL briefly, and must not be
+        // treated as live during that window.
+        Thread.sleep(2_500);
+
+        assertThat(store.estimatedSize())
+                .as("entries past their TTL must be reclaimed, not merely reported as absent")
+                .isZero();
+    }
+
+    @Test
+    void anExpiredKeyIsReclaimableByTheNextClaim() throws Exception {
+        store.claim("k", "fp", Duration.ofMillis(50));
+        Thread.sleep(200);
+
+        assertThat(store.find("k")).isEmpty();
+        assertThat(store.claim("k", "fp", Duration.ofMinutes(5)))
+                .isInstanceOf(ClaimResult.Acquired.class);
+    }
+
+    /**
+     * Reading must not extend a record's life. An idempotency window is absolute - a key is valid
+     * for its TTL from when it was claimed - so a heavily replayed key must still expire on time.
+     * Caffeine's default read policy would renew it, which is why the expiry explicitly returns the
+     * remaining duration on read.
+     */
+    @Test
+    void repeatedReadsDoNotExtendTheTtl() throws Exception {
+        store.claim("k", "fp", Duration.ofMillis(300));
+        for (int i = 0; i < 20; i++) {
+            store.find("k");
+            Thread.sleep(20);
+        }
+        assertThat(store.find("k"))
+                .as("the key was read constantly but its window still ended on schedule")
+                .isEmpty();
+    }
+
+    @Test
+    void memoryIsBoundedWhenNewKeysOutrunExpiry() {
+        var bounded = new CaffeineIdempotencyStore(100);
+        for (int i = 0; i < 5_000; i++) {
+            bounded.claim("k-" + i, "fp", Duration.ofHours(1));
+        }
+        assertThat(bounded.estimatedSize())
+                .as("the ceiling is what keeps a long-running single instance from growing without limit")
+                .isLessThanOrEqualTo(100);
+    }
+
+    /** Two duplicates racing the same fresh key: exactly one may be told it acquired it. */
+    @Test
+    void concurrentClaimsOnTheSameKeyProduceExactlyOneWinner() throws Exception {
+        int threads = 32;
+        var go = new CountDownLatch(1);
+        var acquired = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new java.util.ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    go.await();
+                    if (store.claim("race", "fp", Duration.ofMinutes(5)) instanceof ClaimResult.Acquired) {
+                        acquired.incrementAndGet();
+                    }
+                    return null;
+                }));
+            }
+            go.countDown();
+            for (Future<?> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+        assertThat(acquired.get()).isEqualTo(1);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/IdempotencySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/IdempotencySqlDialect.java
@@ -1,0 +1,56 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * The database-specific half of {@link JdbcIdempotencyStore}.
+ *
+ * <p>Only four statements differ between engines, but one of them - the claim - is the whole
+ * correctness argument of this library, so it is worth being explicit about what a dialect has to
+ * guarantee rather than treating this as string templating.
+ *
+ * <p><strong>The claim must be atomic</strong>: no read-then-write window, and two concurrent
+ * duplicates must never both be told they acquired the key. An expired row must be reclaimable by
+ * the claim itself, or a key whose owner crashed would stay locked until a sweeper happened to
+ * run. How many statements that takes is the dialect's business - see {@link #tryAcquire}.
+ *
+ * <p>Dialects must also agree on "now". Every expiry decision is made by the database, never the
+ * JVM: with several application instances and any clock skew, comparing against each instance's own
+ * {@code Instant.now()} would make the same row look expired on one and live on another. The
+ * function chosen must additionally be one that advances <em>within</em> a transaction - Postgres's
+ * {@code now()} is frozen at transaction start, which is why {@code clock_timestamp()} is used
+ * there.
+ *
+ * <p>Public only because Spring auto-configuration in another module selects an implementation.
+ * Like everything in this package it is <strong>not part of the supported API</strong>.
+ */
+public interface IdempotencySqlDialect {
+
+    /** Human-readable name, used in startup logging and failure messages. */
+    String name();
+
+    /**
+     * Atomically take the key, or report that someone else holds it.
+     *
+     * <p>This is a method rather than a SQL string because the two engines need genuinely different
+     * <em>algorithms</em>, not merely different syntax. Postgres can express the whole thing as one
+     * statement whose affected-row count is trustworthy; MySQL cannot, because its JDBC driver
+     * defaults to reporting <em>matched</em> rather than <em>changed</em> rows, which makes an
+     * unchanged duplicate indistinguishable from a fresh insert. Hiding that behind a shared
+     * template would have meant every MySQL duplicate silently executing.
+     *
+     * @return {@code true} if this caller now owns the key - either freshly inserted, or reclaimed
+     *         from an expired row. {@code false} means a live row is held by someone else.
+     */
+    boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id, String fingerprint,
+            long ttlMillis);
+
+    /** Parameters: {@code :id}, {@code :fp}, {@code :status}, {@code :payloadType}, {@code :payload}, {@code :ttlMillis}. */
+    String completeSql(String tableName);
+
+    /** Parameters: {@code :id}. */
+    String releaseSql(String tableName);
+
+    /** Parameters: {@code :id}. Must not return rows that have already expired. */
+    String findSql(String tableName);
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStore.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStore.java
@@ -35,48 +35,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcIdempotencyStore implements IdempotencyStore {
 
     private final NamedParameterJdbcTemplate jdbc;
-    private final String claimSql;
-    private final String completeSql;
-    private final String releaseSql;
-    private final String findSql;
+    // Memoized rather than built in the constructor: with dialect=auto the dialect has not
+    // been resolved yet at construction time, and asking it for SQL would force a database
+    // connection during startup - see LazySqlDialect for why that must not happen.
+    private volatile String completeSql;
+    private volatile String releaseSql;
+    private volatile String findSql;
     private final RowMapper<IdempotencyRecord> rowMapper = this::mapRow;
 
-    public JdbcIdempotencyStore(NamedParameterJdbcTemplate jdbc, String tableName) {
+    private final IdempotencySqlDialect dialect;
+
+    private final String tableName;
+
+    public JdbcIdempotencyStore(NamedParameterJdbcTemplate jdbc, String tableName,
+            IdempotencySqlDialect dialect) {
         this.jdbc = jdbc;
-        this.claimSql = """
-                INSERT INTO %s
-                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
-                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, clock_timestamp(),
-                        clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond'))
-                ON CONFLICT (id) DO UPDATE SET
-                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
-                    payload_type = NULL, payload = NULL, created_at = clock_timestamp(),
-                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
-                WHERE %s.expires_at < clock_timestamp()
-                """.formatted(tableName, tableName);
-        this.completeSql = """
-                UPDATE %s SET
-                    state = 'COMPLETED', fingerprint = :fp, status = :status,
-                    payload_type = :payloadType, payload = :payload,
-                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
-                WHERE id = :id
-                """.formatted(tableName);
-        this.releaseSql = "DELETE FROM %s WHERE id = :id".formatted(tableName);
-        this.findSql = """
-                SELECT state, fingerprint, status, payload_type, payload, created_at
-                FROM %s WHERE id = :id AND expires_at >= clock_timestamp()
-                """.formatted(tableName);
+        this.dialect = dialect;
+        this.tableName = tableName;
     }
 
     @Override
     public ClaimResult claim(String key, String fingerprint, Duration ttl) {
-        int rows = jdbc.update(claimSql, new MapSqlParameterSource()
-                .addValue("id", key)
-                .addValue("fp", fingerprint)
-                .addValue("ttlMillis", ttl.toMillis()));
-        if (rows == 1) {
+        if (dialect.tryAcquire(jdbc, tableName, key, fingerprint, ttl.toMillis())) {
             return new ClaimResult.Acquired();
         }
+        // Lost the claim, so read back whoever holds it. The Optional can still be empty if that
+        // row expired or was released in the gap - in which case nobody holds the key any more and
+        // the caller is free to proceed.
         return find(key)
                 .<ClaimResult>map(ClaimResult.AlreadyHeld::new)
                 .orElseGet(ClaimResult.Acquired::new);
@@ -85,7 +70,7 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public void complete(String key, IdempotencyRecord record, Duration ttl) {
-        jdbc.update(completeSql, new MapSqlParameterSource()
+        jdbc.update(completeSql(), new MapSqlParameterSource()
                 .addValue("id", key)
                 .addValue("fp", record.fingerprint())
                 .addValue("status", record.status())
@@ -97,13 +82,28 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void release(String key) {
-        jdbc.update(releaseSql, Map.of("id", key));
+        jdbc.update(releaseSql(), Map.of("id", key));
     }
 
     @Override
     public Optional<IdempotencyRecord> find(String key) {
-        var rows = jdbc.query(findSql, new MapSqlParameterSource().addValue("id", key), rowMapper);
+        var rows = jdbc.query(findSql(), new MapSqlParameterSource().addValue("id", key), rowMapper);
         return rows.stream().findFirst();
+    }
+
+    private String completeSql() {
+        String sql = completeSql;
+        return sql != null ? sql : (completeSql = dialect.completeSql(tableName));
+    }
+
+    private String releaseSql() {
+        String sql = releaseSql;
+        return sql != null ? sql : (releaseSql = dialect.releaseSql(tableName));
+    }
+
+    private String findSql() {
+        String sql = findSql;
+        return sql != null ? sql : (findSql = dialect.findSql(tableName));
     }
 
     private IdempotencyRecord mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/LazySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/LazySqlDialect.java
@@ -1,0 +1,72 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Auto-detection that does not touch the database until the first request needs it.
+ *
+ * <p>Detecting eagerly, at bean creation, seems harmless and is not: it opens a connection during
+ * startup, so a database that is merely slow to come up - or deliberately unreachable, which is the
+ * documented {@code idempotency.on-store-failure=proceed} scenario - takes the whole application
+ * down instead of degrading the way it is supposed to. Resolving on first use keeps an unreachable
+ * store a <em>request-time</em> condition, which is where the failure policy can act on it.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public final class LazySqlDialect implements IdempotencySqlDialect {
+
+    private final DataSource dataSource;
+    private volatile IdempotencySqlDialect resolved;
+
+    public LazySqlDialect(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    private IdempotencySqlDialect delegate() {
+        IdempotencySqlDialect local = resolved;
+        if (local == null) {
+            synchronized (this) {
+                local = resolved;
+                if (local == null) {
+                    local = SqlDialectResolver.detect(dataSource);
+                    resolved = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    /**
+     * Deliberately does not resolve. This is used for logging, and a log line is not a good enough
+     * reason to open a database connection - least of all during startup, which is the thing this
+     * class exists to avoid.
+     */
+    @Override
+    public String name() {
+        IdempotencySqlDialect local = resolved;
+        return local == null ? "auto (not yet resolved)" : local.name();
+    }
+
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        return delegate().tryAcquire(jdbc, tableName, id, fingerprint, ttlMillis);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return delegate().completeSql(tableName);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return delegate().releaseSql(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return delegate().findSql(tableName);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/MySqlDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/MySqlDialect.java
@@ -1,0 +1,117 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * MySQL and MariaDB.
+ *
+ * <p>{@code CURRENT_TIMESTAMP(6)} is the counterpart to Postgres's {@code clock_timestamp()}: MySQL
+ * evaluates it per statement rather than freezing it for the transaction, which is the property the
+ * claim needs. The {@code (6)} matters - without it MySQL truncates to whole seconds, so a TTL
+ * shorter than a second would round to nothing and two claims in the same second would compare as
+ * equal.
+ */
+public final class MySqlDialect implements IdempotencySqlDialect {
+
+    private static final String EXPIRY =
+            "DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL (:ttlMillis * 1000) MICROSECOND)";
+
+    @Override
+    public String name() {
+        return "MySQL";
+    }
+
+    /**
+     * Reclaim-then-insert, rather than the single {@code INSERT ... ON DUPLICATE KEY UPDATE} the
+     * Postgres dialect's shape would suggest.
+     *
+     * <p>The obvious upsert does not work here, and fails in the worst possible way. Connector/J
+     * defaults to {@code useAffectedRows=false}, which sets {@code CLIENT_FOUND_ROWS} and makes the
+     * driver report <em>matched</em> rows instead of <em>changed</em> ones. A duplicate that
+     * deliberately changed nothing then reports 1 - identical to a fresh insert - so every duplicate
+     * reads as a successful claim and executes. That is not a subtle degradation; it is the library
+     * doing the exact opposite of its job, and it depends on a connection-string option the
+     * application owns rather than this code.
+     *
+     * <p>Both statements below are immune to that, because each is conditional in its own
+     * {@code WHERE} clause rather than in its update count:
+     *
+     * <ol>
+     *   <li>The {@code UPDATE} matches only an <em>expired</em> row. A live row is excluded by the
+     *       predicate, so it matches zero rows under either driver mode. When it does match, it
+     *       always changes values, so matched and changed agree.</li>
+     *   <li>If nothing was reclaimed, the {@code INSERT} either succeeds - the key was absent - or
+     *       violates the primary key, which Spring surfaces as {@link DuplicateKeyException}. That
+     *       is an exception, not a count, so no driver setting can blur it.</li>
+     * </ol>
+     *
+     * <p>Concurrency holds because InnoDB takes a row lock for the {@code UPDATE} and a unique-index
+     * lock for the {@code INSERT}. Two callers racing an expired row: the first reclaims it and
+     * pushes {@code expires_at} into the future, so the second no longer matches the predicate, falls
+     * through, and collides on the primary key. Exactly one wins.
+     */
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        var params = new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("fp", fingerprint)
+                .addValue("ttlMillis", ttlMillis);
+
+        if (jdbc.update(reclaimExpiredSql(tableName), params) > 0) {
+            return true;
+        }
+        try {
+            jdbc.update(insertSql(tableName), params);
+            return true;
+        } catch (DuplicateKeyException alreadyHeld) {
+            // Someone else holds a live row. The caller reads it back to build the AlreadyHeld
+            // result; swallowing the exception here is the whole signal.
+            return false;
+        }
+    }
+
+    private String reclaimExpiredSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
+                    payload_type = NULL, payload = NULL, created_at = CURRENT_TIMESTAMP(6),
+                    expires_at = %s
+                WHERE id = :id AND expires_at < CURRENT_TIMESTAMP(6)
+                """.formatted(tableName, EXPIRY);
+    }
+
+    private String insertSql(String tableName) {
+        return """
+                INSERT INTO %s
+                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
+                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, CURRENT_TIMESTAMP(6), %s)
+                """.formatted(tableName, EXPIRY);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'COMPLETED', fingerprint = :fp, status = :status,
+                    payload_type = :payloadType, payload = :payload,
+                    expires_at = %s
+                WHERE id = :id
+                """.formatted(tableName, EXPIRY);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return "DELETE FROM %s WHERE id = :id".formatted(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return """
+                SELECT state, fingerprint, status, payload_type, payload, created_at
+                FROM %s WHERE id = :id AND expires_at >= CURRENT_TIMESTAMP(6)
+                """.formatted(tableName);
+    }
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/PostgresDialect.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/PostgresDialect.java
@@ -1,0 +1,75 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Postgres. The original dialect, extracted from {@link JdbcIdempotencyStore} unchanged when MySQL
+ * support was added - the SQL here is byte-for-byte what shipped in 0.1 and 0.2.
+ *
+ * <p>{@code clock_timestamp()} and not {@code now()}: the latter is frozen at transaction start, so
+ * a long-running transaction would keep comparing against a stale "now" and see expired rows as
+ * live.
+ */
+public final class PostgresDialect implements IdempotencySqlDialect {
+
+    @Override
+    public String name() {
+        return "PostgreSQL";
+    }
+
+    @Override
+    public boolean tryAcquire(NamedParameterJdbcTemplate jdbc, String tableName, String id,
+            String fingerprint, long ttlMillis) {
+        int rows = jdbc.update(claimSql(tableName), new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("fp", fingerprint)
+                .addValue("ttlMillis", ttlMillis));
+        // Postgres reports exactly one row for both the insert and the reclaiming update, and
+        // zero when the WHERE excluded a live row. The pgjdbc driver has no found-rows mode, so
+        // unlike MySQL this count means what it says.
+        return rows == 1;
+    }
+
+    private String claimSql(String tableName) {
+        // ON CONFLICT ... DO UPDATE ... WHERE is the whole trick: the WHERE is evaluated against the
+        // existing row, so a live row matches nothing and the statement reports zero rows without
+        // ever touching it.
+        return """
+                INSERT INTO %s
+                    (id, state, fingerprint, status, payload_type, payload, created_at, expires_at)
+                VALUES (:id, 'IN_PROGRESS', :fp, NULL, NULL, NULL, clock_timestamp(),
+                        clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond'))
+                ON CONFLICT (id) DO UPDATE SET
+                    state = 'IN_PROGRESS', fingerprint = :fp, status = NULL,
+                    payload_type = NULL, payload = NULL, created_at = clock_timestamp(),
+                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
+                WHERE %s.expires_at < clock_timestamp()
+                """.formatted(tableName, tableName);
+    }
+
+    @Override
+    public String completeSql(String tableName) {
+        return """
+                UPDATE %s SET
+                    state = 'COMPLETED', fingerprint = :fp, status = :status,
+                    payload_type = :payloadType, payload = :payload,
+                    expires_at = clock_timestamp() + (:ttlMillis * INTERVAL '1 millisecond')
+                WHERE id = :id
+                """.formatted(tableName);
+    }
+
+    @Override
+    public String releaseSql(String tableName) {
+        return "DELETE FROM %s WHERE id = :id".formatted(tableName);
+    }
+
+    @Override
+    public String findSql(String tableName) {
+        return """
+                SELECT state, fingerprint, status, payload_type, payload, created_at
+                FROM %s WHERE id = :id AND expires_at >= clock_timestamp()
+                """.formatted(tableName);
+    }
+
+}

--- a/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolver.java
+++ b/idempotency-store-jdbc/src/main/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolver.java
@@ -1,0 +1,61 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Locale;
+import javax.sql.DataSource;
+
+/**
+ * Picks the {@link IdempotencySqlDialect} for a {@code DataSource}, either from an explicit setting
+ * or by asking the database what it is.
+ *
+ * <p>Detection happens once, at startup, and fails loudly. A store that silently guessed wrong would
+ * not throw - it would issue SQL the engine happens to accept and get the claim semantics subtly
+ * wrong, which surfaces as duplicate executions under concurrency rather than as an error anyone
+ * could trace back here.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public final class SqlDialectResolver {
+
+    private SqlDialectResolver() {
+    }
+
+    /** Detects the dialect from the connection's reported product name. */
+    public static IdempotencySqlDialect detect(DataSource dataSource) {
+        String product;
+        try (Connection connection = dataSource.getConnection()) {
+            product = connection.getMetaData().getDatabaseProductName();
+        } catch (SQLException e) {
+            throw new IllegalStateException(
+                    "idempotency.store=jdbc with idempotency.jdbc.dialect=auto could not connect to the "
+                    + "DataSource to detect which database it is. Fix the DataSource, or set "
+                    + "idempotency.jdbc.dialect explicitly (postgres or mysql) to skip detection.", e);
+        }
+        return forProductName(product);
+    }
+
+    /**
+     * Maps a JDBC product name to a dialect.
+     *
+     * <p>MariaDB reports itself as "MariaDB" but is wire- and SQL-compatible with MySQL for
+     * everything the claim uses, including {@code ON DUPLICATE KEY UPDATE} and
+     * {@code CURRENT_TIMESTAMP(6)}, so it maps to the same dialect. Amazon Aurora reports the engine
+     * it emulates, so it needs no special case.
+     */
+    static IdempotencySqlDialect forProductName(String productName) {
+        String normalized = productName == null ? "" : productName.toLowerCase(Locale.ROOT);
+        if (normalized.contains("postgresql")) {
+            return new PostgresDialect();
+        }
+        if (normalized.contains("mysql") || normalized.contains("mariadb")) {
+            return new MySqlDialect();
+        }
+        throw new IllegalStateException(
+                "Unsupported database for idempotency.store=jdbc: the DataSource reports itself as \""
+                + productName + "\", and only PostgreSQL and MySQL/MariaDB are implemented. Set "
+                + "idempotency.jdbc.dialect explicitly if this database is compatible with one of "
+                + "them, or use idempotency.store=redis.");
+    }
+}

--- a/idempotency-store-jdbc/src/main/resources/db/idempotency/mysql.sql
+++ b/idempotency-store-jdbc/src/main/resources/db/idempotency/mysql.sql
@@ -1,0 +1,23 @@
+-- MySQL / MariaDB schema. Apply the same way as postgres.sql:
+--   spring.sql.init.schema-locations=classpath:db/idempotency/mysql.sql
+--
+-- DATETIME(6), not TIMESTAMP: TIMESTAMP is limited to 2038 and silently converts through the
+-- session time zone on both write and read, which would make expiry depend on the connecting
+-- client's zone. Expiry is decided entirely server-side by comparing against CURRENT_TIMESTAMP(6),
+-- so the column only has to be consistent with itself.
+--
+-- The (6) is not decorative. Without it MySQL truncates to whole seconds, so a sub-second TTL would
+-- round to zero and two claims within the same second would compare as equal.
+CREATE TABLE IF NOT EXISTS idempotency_record (
+    id            VARCHAR(64)  NOT NULL PRIMARY KEY,
+    state         VARCHAR(16)  NOT NULL,
+    fingerprint   VARCHAR(64)  NOT NULL,
+    status        INT,
+    payload_type  VARCHAR(512),
+    payload       LONGTEXT,
+    created_at    DATETIME(6)  NOT NULL,
+    expires_at    DATETIME(6)  NOT NULL,
+    -- Declared inline because MySQL has no CREATE INDEX IF NOT EXISTS; re-running this file must
+    -- stay harmless.
+    INDEX ix_idempotency_expires (expires_at)
+) ENGINE = InnoDB;

--- a/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStoreTest.java
+++ b/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/JdbcIdempotencyStoreTest.java
@@ -69,7 +69,8 @@ class JdbcIdempotencyStoreTest {
     }
 
     private JdbcIdempotencyStore store() {
-        return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), "idempotency_record");
+        return new JdbcIdempotencyStore(new NamedParameterJdbcTemplate(dataSource), "idempotency_record",
+                new PostgresDialect());
     }
 
     /**

--- a/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolverTest.java
+++ b/idempotency-store-jdbc/src/test/java/io/github/benhendayoussef/idempotency/store/jdbc/internal/SqlDialectResolverTest.java
@@ -1,0 +1,51 @@
+package io.github.benhendayoussef.idempotency.store.jdbc.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Product-name mapping. Cheap to test directly, and worth doing so: the consequence of getting it
+ * wrong is not an error but the wrong SQL dialect running successfully against the wrong engine.
+ */
+class SqlDialectResolverTest {
+
+    @Test
+    void postgresVariantsMapToThePostgresDialect() {
+        assertThat(SqlDialectResolver.forProductName("PostgreSQL").name()).isEqualTo("PostgreSQL");
+    }
+
+    @Test
+    void mySqlMapsToTheMySqlDialect() {
+        assertThat(SqlDialectResolver.forProductName("MySQL").name()).isEqualTo("MySQL");
+    }
+
+    /** MariaDB reports its own name but is compatible with everything the claim uses. */
+    @Test
+    void mariaDbIsTreatedAsMySql() {
+        assertThat(SqlDialectResolver.forProductName("MariaDB").name()).isEqualTo("MySQL");
+    }
+
+    @Test
+    void matchingIsCaseInsensitive() {
+        // JDBC drivers are inconsistent about casing, and this is a plain string comparison.
+        assertThat(SqlDialectResolver.forProductName("postgresql").name()).isEqualTo("PostgreSQL");
+        assertThat(SqlDialectResolver.forProductName("MYSQL").name()).isEqualTo("MySQL");
+    }
+
+    @Test
+    void anUnsupportedDatabaseFailsNamingItselfAndTheEscapeHatch() {
+        // Failing loudly beats guessing: the wrong dialect would run, not error.
+        assertThatThrownBy(() -> SqlDialectResolver.forProductName("H2"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("H2")
+                .hasMessageContaining("idempotency.jdbc.dialect");
+    }
+
+    @Test
+    void aNullProductNameIsReportedRatherThanThrowingNullPointer() {
+        assertThatThrownBy(() -> SqlDialectResolver.forProductName(null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/idempotency-webflux/build.gradle.kts
+++ b/idempotency-webflux/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("java-library")
+}
+
+description = "WebFlux support for @Idempotent: a reactive aspect for Mono-returning handlers."
+
+dependencies {
+    api(project(":idempotency-core"))
+    api("org.springframework:spring-webflux")
+    api("io.projectreactor:reactor-core")
+    implementation("org.springframework:spring-web")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("org.aspectj:aspectjweaver")
+    implementation("org.slf4j:slf4j-api")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
+    testImplementation("io.projectreactor:reactor-test")
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/IdempotencyExchangeContextFilter.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/IdempotencyExchangeContextFilter.java
@@ -1,0 +1,44 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import org.springframework.core.Ordered;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Puts the {@link ServerWebExchange} into the Reactor context so the aspect can reach it.
+ *
+ * <p>The servlet aspect reads the current request from {@code RequestContextHolder}, a ThreadLocal.
+ * That has no reactive equivalent: a single request is handled across whatever threads the operators
+ * happen to run on, so there is no "current request" for a thread to hold. The Reactor context is
+ * the reactive counterpart - it travels with the subscription rather than with a thread - and the
+ * only way to get the exchange into it is a filter that writes it there.
+ *
+ * <p>The context propagates <em>upstream</em>, from subscriber toward publisher, which is why
+ * {@code contextWrite} is applied to the result of {@code chain.filter(...)} rather than before it:
+ * everything downstream of this filter, the handler and the aspect included, then sees the value.
+ *
+ * <p>Public only for auto-configuration in another module; <strong>not part of the supported
+ * API</strong>.
+ */
+public class IdempotencyExchangeContextFilter implements WebFilter, Ordered {
+
+    /** Context key. Class-name based so it cannot collide with an application's own entries. */
+    public static final String CONTEXT_KEY = IdempotencyExchangeContextFilter.class.getName();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange).contextWrite(ctx -> ctx.put(CONTEXT_KEY, exchange));
+    }
+
+    /**
+     * Runs before anything that might need the exchange. Ordered explicitly rather than left to
+     * registration order, because a filter that writes the context after the handler has already
+     * been invoked would be silently useless - the aspect would just never find the exchange.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 100;
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveIdempotencyAspect.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveIdempotencyAspect.java
@@ -1,0 +1,439 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benhendayoussef.idempotency.api.ConflictPolicy;
+import io.github.benhendayoussef.idempotency.api.FingerprintMismatchException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyConflictException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyKeyRequiredException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
+import io.github.benhendayoussef.idempotency.api.IdempotencyRecord.State;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStore.ClaimResult;
+import io.github.benhendayoussef.idempotency.api.IdempotencyStoreUnavailableException;
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import io.github.benhendayoussef.idempotency.config.IdempotencyProperties;
+import io.github.benhendayoussef.idempotency.internal.ArgumentFingerprinter;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * The WebFlux counterpart to {@code IdempotencyAspect}, for handlers that return {@code Mono}.
+ *
+ * <p>It is a separate aspect rather than a branch inside the servlet one because almost nothing
+ * carries over. The servlet aspect reads the request from a ThreadLocal, calls the store inline, and
+ * decides the outcome before returning; here the request lives in the Reactor context, every store
+ * call has to leave the event loop, and the outcome is only known when the returned {@code Mono}
+ * completes - so the whole claim/execute/complete sequence is assembled as an operator chain instead
+ * of executed as statements.
+ *
+ * <h2>Two limitations worth stating plainly</h2>
+ *
+ * <p><strong>The store is blocking, so store calls run on {@code boundedElastic}.</strong> Every
+ * {@code IdempotencyStore} implementation is synchronous JDBC or Lettuce-blocking, and calling one
+ * on an event-loop thread is the classic way to stall a reactive application. Scheduling them onto
+ * the elastic pool is correct but it is not free: an idempotent endpoint costs two thread handoffs
+ * that a plain one does not. A genuinely reactive store SPI (R2DBC, reactive Redis) would remove
+ * that, and is deliberately not in this change.
+ *
+ * <p><strong>Only {@code Mono} is advised.</strong> A {@code Flux} return is a stream, and this
+ * library captures a single response value to replay later - the same reason the servlet side does
+ * not support streaming responses. A {@code Flux}-returning handler passes through untouched rather
+ * than being half-supported.
+ */
+@Aspect
+public class ReactiveIdempotencyAspect implements Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(ReactiveIdempotencyAspect.class);
+
+    /** Marks a stored record as an error response rather than a handler return value. */
+    private static final String ERROR_PAYLOAD_TYPE = "!error";
+
+    private final IdempotencyStore store;
+    private final IdempotencyProperties props;
+    private final ArgumentFingerprinter fingerprinter;
+    private final ObjectMapper payloadMapper;
+    private final IdempotencyMetrics metrics;
+
+    public ReactiveIdempotencyAspect(IdempotencyStore store, IdempotencyProperties props,
+            ArgumentFingerprinter fingerprinter, ObjectMapper payloadMapper, IdempotencyMetrics metrics) {
+        this.store = store;
+        this.props = props;
+        this.fingerprinter = fingerprinter;
+        this.payloadMapper = payloadMapper;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public int getOrder() {
+        return props.getAspectOrder();
+    }
+
+    @Around("@annotation(io.github.benhendayoussef.idempotency.api.Idempotent)")
+    public Object around(ProceedingJoinPoint pjp) throws Throwable {
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+
+        if (!Mono.class.isAssignableFrom(method.getReturnType())) {
+            // Flux, or a plain blocking return in a reactive application. Passing it through is the
+            // honest outcome: advising it would either block the event loop or capture only the
+            // first element of a stream, and both are worse than doing nothing.
+            log.warn("@Idempotent on {}.{} returns {} - only Mono is supported on WebFlux, so the "
+                            + "annotation has no effect here",
+                    method.getDeclaringClass().getSimpleName(), method.getName(),
+                    method.getReturnType().getSimpleName());
+            return pjp.proceed();
+        }
+
+        Idempotent ann = method.getAnnotation(Idempotent.class);
+
+        // deferContextual, not defer: the exchange is only reachable once someone subscribes, and
+        // nothing before that point knows which request this is.
+        return Mono.deferContextual(ctx -> {
+            ServerWebExchange exchange = ctx.hasKey(IdempotencyExchangeContextFilter.CONTEXT_KEY)
+                    ? ctx.get(IdempotencyExchangeContextFilter.CONTEXT_KEY)
+                    : null;
+            if (exchange == null) {
+                // The filter is auto-registered, so this means someone replaced the filter chain.
+                // Failing loudly beats silently executing every duplicate.
+                return Mono.error(new IllegalStateException(
+                        "No ServerWebExchange in the Reactor context. IdempotencyExchangeContextFilter "
+                        + "must be registered as a WebFilter for @Idempotent to work on WebFlux."));
+            }
+            return applyIdempotency(pjp, method, ann, exchange);
+        });
+    }
+
+    private Mono<Object> applyIdempotency(ProceedingJoinPoint pjp, Method method, Idempotent ann,
+            ServerWebExchange exchange) {
+        String headerName = ann.keyHeader().isBlank() ? props.getHeaderName() : ann.keyHeader();
+        String clientKey = exchange.getRequest().getHeaders().getFirst(headerName);
+
+        if (clientKey == null || clientKey.isBlank()) {
+            metrics.missingKey();
+            if (props.isRequireKey()) {
+                return Mono.error(new IdempotencyKeyRequiredException());
+            }
+            return proceedAsMono(pjp);
+        }
+
+        String storeKey = ReactiveKeyComposer.compose(clientKey, "", exchange);
+        String fingerprint = ann.fingerprintArgs() ? fingerprinter.fingerprint(method, pjp.getArgs()) : "";
+        Duration ttl = ann.ttl().isBlank() ? props.getDefaultTtl() : Duration.parse("PT" + ann.ttl());
+
+        // The claim result is carried in an Optional rather than signalled by an empty Mono. An
+        // earlier version used switchIfEmpty to mean "the store failed, proceed unprotected", which
+        // was wrong in a way only a handler returning Mono.empty() reveals: a legitimately empty
+        // response also completes empty, so the handler ran a second time - and a replay of that
+        // stored empty response ran it a third. Emptiness is a valid outcome here, so it cannot
+        // double as a control signal.
+        return blocking(() -> store.claim(storeKey, fingerprint, ttl))
+                .map(java.util.Optional::of)
+                .onErrorResume(RuntimeException.class, this::onClaimFailure)
+                .flatMap(claim -> claim
+                        .map(c -> c instanceof ClaimResult.AlreadyHeld held
+                                ? handleExisting(pjp, method, held.record(), storeKey, fingerprint, ttl)
+                                : execute(pjp, method, storeKey, fingerprint, ttl))
+                        // Empty Optional: the store was unreachable and the policy said PROCEED.
+                        .orElseGet(() -> proceedAsMono(pjp)));
+    }
+
+    private Mono<java.util.Optional<ClaimResult>> onClaimFailure(RuntimeException e) {
+        metrics.storeFailure();
+        if (props.getOnStoreFailure() == IdempotencyProperties.OnStoreFailure.FAIL) {
+            return Mono.error(new IdempotencyStoreUnavailableException(e));
+        }
+        log.warn("Idempotency store unavailable; executing unprotected per idempotency.on-store-failure", e);
+        return Mono.just(java.util.Optional.empty());
+    }
+
+    // --- Execute path -------------------------------------------------------------------------
+
+    private Mono<Object> execute(ProceedingJoinPoint pjp, Method method, String storeKey,
+            String fingerprint, Duration ttl) {
+        // singleOptional, not a bare flatMap: a handler returning Mono.empty() is a legitimate
+        // response with no body, and it must still be recorded as completed. Without lifting the
+        // emptiness into a value the completion step would never run for those handlers and the key
+        // would sit IN_PROGRESS until its TTL - every later duplicate blocking or 409-ing against a
+        // request that actually succeeded.
+        return proceedAsMono(pjp)
+                .singleOptional()
+                .flatMap(result -> completeThen(result.orElse(null), method, storeKey, fingerprint, ttl)
+                        .then(Mono.justOrEmpty(result)))
+                .onErrorResume(t -> settleFailure(storeKey, fingerprint, ttl, t).then(Mono.error(t)));
+    }
+
+    private Mono<Void> completeThen(Object result, Method method, String storeKey, String fingerprint,
+            Duration ttl) {
+        IdempotencyRecord record = toRecord(result, fingerprint, method);
+        if (exceedsMaxPayload(record)) {
+            return blocking(() -> {
+                store.release(storeKey);
+                log.warn("Idempotent response for key {} exceeds idempotency.max-payload-size; not cached",
+                        storeKey);
+                metrics.executed();
+                return true;
+            }).then();
+        }
+        return blocking(() -> {
+            store.complete(storeKey, record, ttl);
+            metrics.executed();
+            return true;
+        }).then();
+    }
+
+    private Mono<Void> settleFailure(String storeKey, String fingerprint, Duration ttl, Throwable t) {
+        if (shouldRelease(t)) {
+            return blocking(() -> {
+                store.release(storeKey);
+                metrics.released();
+                return null;
+            }).then();
+        }
+        return blocking(() -> {
+            store.complete(storeKey, toErrorRecord(t, fingerprint), ttl);
+            return null;
+        }).then();
+    }
+
+    // --- Replay / conflict path ---------------------------------------------------------------
+
+    private Mono<Object> handleExisting(ProceedingJoinPoint pjp, Method method, IdempotencyRecord record,
+            String storeKey, String fingerprint, Duration ttl) {
+        if (!fingerprint.isEmpty() && !fingerprint.equals(record.fingerprint())) {
+            metrics.fingerprintMismatch();
+            return Mono.error(new FingerprintMismatchException());
+        }
+        if (record.state() == State.COMPLETED) {
+            metrics.replayed();
+            return replay(record, method);
+        }
+        if (props.getOnConflict() == ConflictPolicy.FAIL_FAST) {
+            metrics.conflict();
+            return Mono.error(new IdempotencyConflictException());
+        }
+        return waitForCompletion(method, storeKey);
+    }
+
+    /**
+     * WAIT policy. Polls the store until the in-flight request finishes or the timeout expires.
+     *
+     * <p>Unlike the servlet implementation this occupies no thread while waiting - the delay is a
+     * timer, not a sleep - which removes the thread-pool exhaustion the servlet side documents as a
+     * limitation. That is the one place the reactive version is meaningfully better.
+     */
+    private Mono<Object> waitForCompletion(Method method, String storeKey) {
+        Duration timeout = props.getWaitTimeout();
+        Duration interval = Duration.ofMillis(50);
+        Instant deadline = Instant.now().plus(timeout);
+
+        return Mono.defer(() -> blocking(() -> store.find(storeKey)))
+                .flatMap(found -> found
+                        .filter(r -> r.state() == State.COMPLETED)
+                        .map(r -> {
+                            metrics.replayedAfterWait();
+                            return replay(r, method);
+                        })
+                        .orElseGet(Mono::empty))
+                .repeatWhenEmpty(flux -> flux
+                        .delayElements(interval)
+                        .takeWhile(i -> Instant.now().isBefore(deadline)))
+                .onErrorResume(IllegalStateException.class, e -> {
+                    // repeatWhenEmpty signals exhaustion this way rather than completing empty.
+                    metrics.waitTimeout();
+                    return Mono.error(new IdempotencyConflictException());
+                });
+    }
+
+    private Mono<Object> replay(IdempotencyRecord record, Method method) {
+        Type payloadType = monoPayloadType(method);
+
+        if (ERROR_PAYLOAD_TYPE.equals(record.payloadType())) {
+            // Always re-thrown, never returned as a value - including when the handler declares
+            // ResponseEntity. WebFlux picks the message writer from the *declared* generic type, so
+            // handing a ProblemDetail body to a method declared Mono<ResponseEntity<Map<..>>> fails
+            // conversion and renders 500: the replayed 4xx would arrive as a server error, which is
+            // the one outcome a retry must never see. Surfacing it as an ErrorResponse makes the
+            // framework render the stored status and body directly, whatever the declared type is.
+            ProblemDetail body = readProblemDetail(record.payload(), record.status());
+            return Mono.error(new ReplayedErrorResponseException(record.status(), body));
+        }
+
+        Object body = record.payload() == null ? null : readJson(record.payload(), innerType(payloadType));
+        if (isResponseEntity(payloadType)) {
+            return Mono.just(ResponseEntity.status(record.status()).body(body));
+        }
+        return body == null ? Mono.empty() : Mono.just(body);
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    /**
+     * Runs a blocking store call off the event loop.
+     *
+     * <p>{@code fromCallable} rather than {@code just}: the call must not happen at assembly time,
+     * only when subscribed. {@code boundedElastic} is the scheduler Reactor provides precisely for
+     * wrapping blocking I/O that cannot be made reactive.
+     */
+    private <T> Mono<T> blocking(java.util.concurrent.Callable<T> call) {
+        return Mono.fromCallable(call).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<Object> proceedAsMono(ProceedingJoinPoint pjp) {
+        try {
+            Object result = pjp.proceed();
+            return result == null ? Mono.empty() : (Mono<Object>) result;
+        } catch (Throwable t) {
+            return Mono.error(t);
+        }
+    }
+
+    /** The {@code T} in a declared {@code Mono<T>}. */
+    private static Type monoPayloadType(Method method) {
+        Type generic = method.getGenericReturnType();
+        if (generic instanceof ParameterizedType pt && pt.getActualTypeArguments().length == 1) {
+            return pt.getActualTypeArguments()[0];
+        }
+        return Object.class;
+    }
+
+    private static boolean isResponseEntity(Type type) {
+        if (type instanceof ParameterizedType pt) {
+            return pt.getRawType() == ResponseEntity.class;
+        }
+        return type == ResponseEntity.class;
+    }
+
+    /** For {@code Mono<ResponseEntity<T>>} the stored body is the {@code T}, not the entity. */
+    private static Type innerType(Type payloadType) {
+        if (isResponseEntity(payloadType) && payloadType instanceof ParameterizedType pt
+                && pt.getActualTypeArguments().length == 1) {
+            return pt.getActualTypeArguments()[0];
+        }
+        return payloadType;
+    }
+
+    private IdempotencyRecord toRecord(Object result, String fingerprint, Method method) {
+        int status = 200;
+        Object body = result;
+        if (result instanceof ResponseEntity<?> re) {
+            status = re.getStatusCode().value();
+            body = re.getBody();
+        }
+        return new IdempotencyRecord(State.COMPLETED, fingerprint, status,
+                monoPayloadType(method).getTypeName(), writeJson(body), Instant.now());
+    }
+
+    private IdempotencyRecord toErrorRecord(Throwable t, String fingerprint) {
+        int status = resolveStatus(t);
+        Object body = (t instanceof ErrorResponse er) ? er.getBody() : problemDetailFor(status, t.getMessage());
+        return new IdempotencyRecord(State.COMPLETED, fingerprint, status, ERROR_PAYLOAD_TYPE,
+                writeJson(body), Instant.now());
+    }
+
+    private static ProblemDetail problemDetailFor(int status, String message) {
+        ProblemDetail pd = ProblemDetail.forStatus(status);
+        if (message != null) {
+            pd.setDetail(message);
+        }
+        return pd;
+    }
+
+    private boolean shouldRelease(Throwable t) {
+        return resolveStatus(t) >= 500
+                && props.getReleaseOn().contains(IdempotencyProperties.ReleaseOn.FIVE_XX);
+    }
+
+    private static int resolveStatus(Throwable t) {
+        if (t instanceof ErrorResponse er) {
+            return er.getStatusCode().value();
+        }
+        var ann = org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation(
+                t.getClass(), org.springframework.web.bind.annotation.ResponseStatus.class);
+        return ann != null ? ann.code().value() : HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
+
+    private boolean exceedsMaxPayload(IdempotencyRecord record) {
+        return record.payload() != null
+                && record.payload().length() > props.getMaxPayloadSize().toBytes();
+    }
+
+    private String writeJson(Object body) {
+        if (body == null) {
+            return null;
+        }
+        try {
+            return payloadMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize idempotent response body", e);
+        }
+    }
+
+    /**
+     * Rebuilds the stored error body.
+     *
+     * <p>Read as a map and reassembled rather than deserialized straight into {@link ProblemDetail}:
+     * that type is built for writing, not reading, and Jackson cannot reliably reconstruct it -
+     * which turned every replayed 4xx into a 500 until this was changed. Going through a map also
+     * preserves any extension members the original carried.
+     */
+    private ProblemDetail readProblemDetail(String json, int status) {
+        ProblemDetail detail = ProblemDetail.forStatus(status);
+        if (json == null) {
+            return detail;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> map = payloadMapper.readValue(json, java.util.Map.class);
+            Object title = map.remove("title");
+            Object det = map.remove("detail");
+            Object instance = map.remove("instance");
+            Object type = map.remove("type");
+            map.remove("status");
+            if (title != null) {
+                detail.setTitle(String.valueOf(title));
+            }
+            if (det != null) {
+                detail.setDetail(String.valueOf(det));
+            }
+            if (instance != null) {
+                detail.setInstance(java.net.URI.create(String.valueOf(instance)));
+            }
+            if (type != null) {
+                detail.setType(java.net.URI.create(String.valueOf(type)));
+            }
+            map.forEach(detail::setProperty);
+            return detail;
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize stored idempotent error response", e);
+        }
+    }
+
+    private Object readJson(String json, Type type) {
+        try {
+            JavaType javaType = payloadMapper.getTypeFactory().constructType(type);
+            return payloadMapper.readValue(json, javaType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize stored idempotent response", e);
+        }
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveKeyComposer.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReactiveKeyComposer.java
@@ -1,0 +1,33 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import io.github.benhendayoussef.idempotency.internal.Hashing;
+import java.util.Objects;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * The WebFlux counterpart to {@code IdempotencyKeyComposer}.
+ *
+ * <p>Produces byte-identical keys to the servlet version for the same request, deliberately: the two
+ * stacks can share a store - a service migrating from MVC to WebFlux one endpoint at a time has
+ * both running against the same Redis - and a key that changed shape mid-migration would silently
+ * stop deduplicating exactly when it mattered.
+ *
+ * <p>The route pattern, not the raw URI, is what goes into the hash. Otherwise {@code /orders/1} and
+ * {@code /orders/2} would be different routes to the deduplication logic even though they are the
+ * same endpoint, and a client reusing one key across them would not be protected.
+ */
+final class ReactiveKeyComposer {
+
+    private ReactiveKeyComposer() {
+    }
+
+    static String compose(String clientKey, String namespace, ServerWebExchange exchange) {
+        // BEST_MATCHING_PATTERN_ATTRIBUTE holds a PathPattern here rather than the String the
+        // servlet stack stores; toString() gives the same pattern text either way.
+        Object pattern = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        String route = Objects.toString(pattern, exchange.getRequest().getPath().value());
+        String method = exchange.getRequest().getMethod().name();
+        return Hashing.sha256Hex(namespace + '|' + method + '|' + route + '|' + clientKey);
+    }
+}

--- a/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReplayedErrorResponseException.java
+++ b/idempotency-webflux/src/main/java/io/github/benhendayoussef/idempotency/webflux/internal/ReplayedErrorResponseException.java
@@ -1,0 +1,54 @@
+package io.github.benhendayoussef.idempotency.webflux.internal;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Carries a replayed error response back out through the reactive pipeline.
+ *
+ * <p>The servlet aspect can write a stored error straight to the {@code HttpServletResponse} when the
+ * handler's declared return type cannot express an arbitrary status. There is no equivalent here -
+ * writing to the response mid-pipeline races the framework's own rendering - so the stored status and
+ * body are surfaced as an exception instead.
+ *
+ * <p>It extends {@link ResponseStatusException} specifically, rather than merely implementing
+ * {@code ErrorResponse}. WebFlux's status handling maps {@code ResponseStatusException}; a plain
+ * exception that only implements {@code ErrorResponse} falls through to the generic handler and
+ * renders <strong>500</strong>. That turns a replayed 400 into a server error - the one answer a
+ * retry must never get, and worse than not replaying at all, since the caller now sees a failure
+ * that never actually happened.
+ */
+final class ReplayedErrorResponseException extends ResponseStatusException {
+
+    private static final long serialVersionUID = 1L;
+
+    ReplayedErrorResponseException(int status, ProblemDetail stored) {
+        super(HttpStatusCode.valueOf(status), stored != null ? stored.getDetail() : null);
+        copyInto(getBody(), stored);
+    }
+
+    /**
+     * {@code getBody()} is final on the superclass, so the recorded body is copied onto the one this
+     * exception already owns rather than replacing it. The effect is the same and it is what matters
+     * here: a retry sees the title, detail and extension members the first caller saw, not a fresh
+     * ProblemDetail rebuilt from the status alone.
+     */
+    private static void copyInto(ProblemDetail target, ProblemDetail stored) {
+        if (stored == null) {
+            return;
+        }
+        if (stored.getTitle() != null) {
+            target.setTitle(stored.getTitle());
+        }
+        if (stored.getType() != null) {
+            target.setType(stored.getType());
+        }
+        if (stored.getInstance() != null) {
+            target.setInstance(stored.getInstance());
+        }
+        if (stored.getProperties() != null) {
+            stored.getProperties().forEach(target::setProperty);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "idempotency-core",
     "idempotency-store-redis",
     "idempotency-store-jdbc",
+    "idempotency-store-caffeine",
     "idempotency-spring-boot-starter",
     "samples:sample-orders-api",
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "idempotency-core",
     "idempotency-store-redis",
     "idempotency-store-jdbc",
+    "idempotency-webflux",
     "idempotency-spring-boot-starter",
     "samples:sample-orders-api",
 )


### PR DESCRIPTION
Integration of all six 0.3.0 features into one reviewable branch: #4 Spring Boot 3, #5 Micrometer, #6 MySQL, #7 Caffeine, #8 WebFlux, #9 filter mode.

**Merging this supersedes those six.** Each was green against `main` in isolation; this is the first time they have existed together.

## Two bugs that only the combination could reveal

Both would have reached `main` had the six been merged one at a time without an integration build in between.

**1. WebFlux was broken on Spring Boot 3.** `WebFluxIdempotencyBehaviorTest` hardcoded the Boot 4 `DataSourceAutoConfiguration` class name in `spring.autoconfigure.exclude`. That class does not exist on Boot 3, so the exclude matched nothing, Boot built an unconfigured `DataSource`, and **every test in the class failed** on a bean that should never have been created. It now uses the shared `TestAutoconfigExcludes` constant, which names both generations — precisely why that constant exists. Neither #4 nor #8 could have caught this alone.

**2. Two tests used an annotation that no longer exists.** #5 and #9 each added a test using `@AutoConfigureMockMvc`, whose module #4 removed. Ported to `MockMvcTestConfiguration`.

## Conflicts resolved

Mostly additive — several branches appended to the same config class, properties file, metadata JSON and README. Three needed real judgement rather than "keep both":

- **The README limitations list.** Each side carried one accurate line and one that this merge makes false. "Postgres only for the JDBC store" and "Servlet stack only" are both untrue once MySQL and WebFlux land, so they are gone; the MySQL, Caffeine and WebFlux entries stay.
- **The servlet aspect's conditions.** #8 gated it on `SERVLET`, #9 on `mode=aspect`. It needs **both** — either alone registers it in a context that must not have it.
- **`IdempotencyAutoConfigurationTest`.** #5 and #6 appended sections that git interleaved mid-method. Rebuilt from both parents rather than patched.

Also fixed in passing: an unescaped-pipe in the `idempotency.jdbc.dialect` README row that was silently breaking the table, and a MySQL test comment still describing the affected-row-count approach that dialect was changed away from.

## Verification

```
./gradlew clean build                          -> BUILD SUCCESSFUL, 248 tests, 0 failures
./gradlew -PspringBootVersion=3.5.6 clean build -> 91 pass, 6 Testcontainers tests fail locally
```

Those 6 are the **known local Windows limitation documented in #4**: Boot 3's BOM pins Testcontainers 1.21.3, which cannot reach Docker Desktop's named pipe (Boot 4 pins 2.0.5, which can). Verified again here — the resolved version is 1.21.3 and the failures are all `Could not find a valid Docker environment`. On Linux CI both generations use the unix socket, which is what the matrix on this PR will show.

248 tests, up from 156 on `main`.

## After merging

Close #4–#9 as superseded, then the release: promote `Unreleased` to `0.3.0` in the changelog, update the compatibility matrix and install snippets, tag `v0.3.0`, and Publish on the Central Portal.
