### PR TITLE
1.0.0 — a stable, supported API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Build and test
         run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} clean build
 
+      # idempotency-core compiles against Spring Security but must never link to it in an
+      # application that only uses idempotency.scope=global. That failure is a NoClassDefFoundError
+      # on the first request rather than at startup, so no context test catches it - this task runs
+      # the check on a classpath with the Spring Security jars genuinely removed.
+      - name: compileOnly boundary check (no Spring Security)
+        run: ./gradlew -PspringBootVersion=${{ matrix.spring-boot }} :idempotency-spring-boot-starter:testNoSpringSecurity
+
       # Virtual threads don't exist on the project's pinned Java 17 toolchain; this task runs the
       # same test sources on a separately-provisioned JDK 21+ launcher without changing what the
       # library is normally built and tested against.

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,71 @@
+name: GitHub Release
+
+# Creates the GitHub Release page for a tag, with notes taken straight from CHANGELOG.md so the
+# release and the changelog can never drift apart.
+#
+# Deliberately separate from release.yml. That one publishes to Maven Central and must run exactly
+# once per version - re-running it for an already-published version would upload a duplicate
+# deployment and burn a monthly publishing slot. This one only writes a page on GitHub and is safe
+# to re-run, which is what makes the manual trigger below usable for backfilling old tags.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to create the release for, e.g. v0.4.0'
+        required: true
+
+# The only permission this needs, and the reason it needs no personal token: GITHUB_TOKEN is minted
+# for the run by GitHub itself.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve the tag
+        run: echo "TAG=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Extract the changelog section for this version
+        run: |
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          # Everything between this version's heading and the next one.
+          #
+          # index() rather than a regex on purpose. Building the pattern as "^## \\[" v "\\]" looks
+          # right and is not: awk strips the backslashes at the string level, so the version lands in
+          # the regex as [0.4.0] - a character class matching one of '0', '.' or '4' - and the whole
+          # extraction silently yields nothing. index() needs no escaping and behaves identically
+          # across gawk, mawk and busybox awk, which is what runners actually vary in.
+          awk -v v="$VERSION" '
+            index($0, "## [" v "]") == 1     { found = 1; next }
+            found && index($0, "## [") == 1  { exit }
+            found                            { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          # A release whose notes are silently empty is worse than a failed workflow: nobody notices
+          # until someone opens the page.
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::No '## [$VERSION]' section found in CHANGELOG.md" >&2
+            exit 1
+          fi
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; updating its notes rather than failing."
+            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+          else
+            gh release create "$TAG" \
+              --title "$VERSION" \
+              --notes-file RELEASE_NOTES.md \
+              --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [1.0.0] - 2026-09-12
+
+**The API is now stable.** Everything in `io.github.benhendayoussef.idempotency.api`, every
+`idempotency.*` property name and meaning, the storage key format, the stored record format, the
+actuator endpoint, and the metric and trace names are covered by semantic versioning from here:
+breaking any of them requires a 2.0. The README's **API stability** section is the full list,
+including what is deliberately *not* covered - every `internal` package, in every module.
+
+No new features. 1.0 is a commitment, not a feature release; the one behavioural change below is
+an API fix made now precisely because it could not be made later.
 
 ### Changed
 
@@ -38,6 +47,24 @@ All notable changes to this project are documented in this file.
   `IdempotencyContext` also carries `clientKey()`, `httpMethod()` and `routePattern()`, none of
   which a resolver could see before. It is an interface rather than a record specifically so it can
   gain accessors in a minor release without breaking implementors.
+
+### Added
+
+- A published **API stability policy** (README), saying exactly what semantic versioning covers
+  here. Two entries are unusual enough to call out: the **storage key format** and the **stored
+  record format**. Changing either would orphan records already in your store or strand in-flight
+  keys during a rolling upgrade, so both are treated as API even though neither is a Java type.
+- `SECURITY.md`, with private vulnerability reporting and - more usefully - what actually counts as
+  a vulnerability in a library like this one. Cross-caller replay and key collision are the real
+  threat classes; a replay to the same caller with the same key is the product working.
+
+### Internal
+
+- A `testNoSpringSecurity` task runs part of the suite with the Spring Security jars genuinely
+  removed from the classpath. `idempotency-core` compiles against Spring Security but must never
+  link to it for a `scope=global` application, and that failure would be a `NoClassDefFoundError`
+  on the first request rather than at startup - invisible to every context test. Runs in CI on both
+  Boot generations.
 
 ## [0.4.0] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking: `ScopeResolver.namespace()` now takes an `IdempotencyContext`.** It previously took
+  no arguments and implementations read `SecurityContextHolder` directly. That single decision is
+  why `idempotency.scope` has always been restricted to `global` on WebFlux - the ThreadLocal is
+  empty on a reactive stack, and falling back to global silently would have shared idempotency keys
+  across users. Handing the resolver its inputs makes the SPI stack-agnostic and testable without
+  standing up a security context, and means reactive scoping can be added later as a purely
+  additive change rather than a second parallel SPI.
+
+  **Migration.** Only affects `idempotency.scope=custom`, or an application that registered its own
+  bean to override a built-in resolver. Add the parameter and take the authentication from the
+  context instead of the ThreadLocal:
+
+  ```java
+  // before
+  public String namespace() {
+      Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+      return auth.getName();
+  }
+
+  // after
+  public String namespace(IdempotencyContext context) {
+      Object auth = context.authentication().orElse(null);
+      if (!(auth instanceof Authentication authentication)) {
+          throw new IllegalStateException("no principal");   // routed through on-missing-principal
+      }
+      return authentication.getName();
+  }
+  ```
+
+  `IdempotencyContext` also carries `clientKey()`, `httpMethod()` and `routePattern()`, none of
+  which a resolver could see before. It is an interface rather than a record specifically so it can
+  gain accessors in a minor release without breaking implementors.
+
 ## [0.4.0] - 2026-09-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -559,11 +559,73 @@ IdempotencyStore idempotencyStore(/* ... */) {
 }
 ```
 
-Other extension points: `ScopeResolver` (custom key namespacing), `IdempotencyMetrics` (wire up
-Micrometer or anything else), `IdempotencyTracer` (send the per-request outcome to your own tracing
-or audit sink), and `IdempotencyObjectMapperCustomizer` (register your application's
-Jackson modules on the starter's internal payload mapper — it deliberately never reuses your
-app's own `ObjectMapper`).
+`ScopeResolver` decides the namespace that keeps one caller's key from colliding with another's.
+Everything it needs arrives in the `IdempotencyContext` — it never reads ambient state, which is
+what lets the same resolver work on any stack:
+
+```java
+@Bean
+ScopeResolver apiKeyScopeResolver() {
+    return new ScopeResolver() {
+        @Override public IdempotencyScope supports() { return IdempotencyScope.CUSTOM; }
+
+        @Override public String namespace(IdempotencyContext context) {
+            Object auth = context.authentication().orElse(null);
+            if (!(auth instanceof MyToken token)) {
+                // IllegalStateException specifically: it routes through
+                // idempotency.on-missing-principal instead of reaching the caller as a 500.
+                throw new IllegalStateException("no API key on this request");
+            }
+            return token.accountId();
+        }
+    };
+}
+```
+
+Other extension points: `IdempotencyMetrics` (wire up Micrometer or anything else),
+`IdempotencyTracer` (send the per-request outcome to your own tracing or audit sink), and
+`IdempotencyObjectMapperCustomizer` (register your application's Jackson modules on the starter's
+internal payload mapper — it deliberately never reuses your app's own `ObjectMapper`).
+
+## API stability
+
+From **1.0.0** this project follows [semantic versioning](https://semver.org), and the point of the
+1.0 line is that the list below is a promise rather than an intention.
+
+**Covered — a breaking change here requires a new major version:**
+
+| | |
+|---|---|
+| `io.github.benhendayoussef.idempotency.api.**` | `@Idempotent` and its attributes, `IdempotencyStore`, `ScopeResolver`, `IdempotencyContext`, `IdempotencyRecord`, `IdempotencyMetrics`, `IdempotencyTracer`, `IdempotencyKeys`, the enums and the exception types |
+| Configuration property names and meanings | Every `idempotency.*` key, its default, and what it does |
+| **The storage key format** | The hash of namespace, method, route and client key. Changing it would orphan every record already in your store |
+| **The stored record format** | A record written by 1.x stays readable by every later 1.x, so a rolling upgrade never strands in-flight keys |
+| The actuator endpoint | Its id, parameters and response fields |
+| Metric and trace names | `idempotency.requests`, its `outcome` tag values, and the `idempotency.outcome` span tag. Values may be *added*; existing ones will not change meaning |
+| Autoconfiguration class names | People name these in `spring.autoconfigure.exclude`, so the names are API even though their `@Bean` methods are not |
+
+**Not covered — these change in any release:**
+
+- **Every `internal` package, in every module.** Each one says so in its own `package-info.java`,
+  and a test enforces that they all do. If you are importing from one, you are outside the
+  supported API — open an issue and say what you needed, because that is a gap worth closing
+  properly.
+- The `@Bean` method signatures inside the autoconfiguration classes.
+- Log message wording.
+- Anything marked `@Deprecated(forRemoval = true)`, after the removal window below.
+
+**Deprecation.** Anything being removed is deprecated in a minor release first, with
+`@Deprecated(since = "1.x", forRemoval = true)` and a javadoc pointer to the replacement. It stays
+for the remainder of the major version — a minor release never removes covered API.
+
+**Spring Boot.** Both supported generations are exercised by the full test suite in CI on every
+push, and dropping one is a major-version change. Java 17 stays the baseline for all of 1.x.
+
+**Adding to an interface.** `IdempotencyMetrics` and `IdempotencyContext` are designed so they can
+grow: every method on them has, or can be given, a default body. New outcomes and new context
+accessors will arrive in minor releases without breaking implementors. `IdempotencyRecord` is a
+record and therefore cannot gain components — if its shape ever has to change, that is a new type,
+not a modified one.
 
 ## Compatibility matrix
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ replayed** — not a re-execution, not an error.
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.4.0") // use the latest published version
-    implementation("io.github.benhendayoussef:idempotency-store-redis:0.4.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:1.0.0") // use the latest published version
+    implementation("io.github.benhendayoussef:idempotency-store-redis:1.0.0")
 }
 ```
 
@@ -54,8 +54,8 @@ The JDBC store needs more setup than swapping one dependency — all of the foll
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.4.0") // use the latest published version
-    implementation("io.github.benhendayoussef:idempotency-store-jdbc:0.4.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:1.0.0") // use the latest published version
+    implementation("io.github.benhendayoussef:idempotency-store-jdbc:1.0.0")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     runtimeOnly("org.postgresql:postgresql")
 }
@@ -89,8 +89,8 @@ acceptable:
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.4.0")
-    implementation("io.github.benhendayoussef:idempotency-store-caffeine:0.4.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:1.0.0")
+    implementation("io.github.benhendayoussef:idempotency-store-caffeine:1.0.0")
 }
 ```
 
@@ -438,9 +438,9 @@ Add `idempotency-webflux` and `@Idempotent` works on reactive handlers that retu
 
 ```kotlin
 dependencies {
-    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:0.4.0")
-    implementation("io.github.benhendayoussef:idempotency-webflux:0.4.0")
-    implementation("io.github.benhendayoussef:idempotency-store-redis:0.4.0")
+    implementation("io.github.benhendayoussef:idempotency-spring-boot-starter:1.0.0")
+    implementation("io.github.benhendayoussef:idempotency-webflux:1.0.0")
+    implementation("io.github.benhendayoussef:idempotency-store-redis:1.0.0")
 }
 ```
 
@@ -631,6 +631,7 @@ not a modified one.
 
 | Starter version | Spring Boot | Java |
 |---|---|---|
+| 1.0.x | **3.5.x and 4.1.x** | 17+ |
 | 0.4.x | **3.5.x and 4.1.x** | 17+ |
 | 0.3.x | **3.5.x and 4.1.x** | 17+ |
 | 0.2.x | 4.1.x (Spring Framework 7) | 17+ |
@@ -645,12 +646,13 @@ lower bound and the full suite runs against both in CI on every push.
 - **0.2** — ✅ Genuine exactly-once for the JDBC store via `idempotency.jdbc.join-transaction`
 - **0.3** — ✅ Spring Boot 3 support, Micrometer metrics, MySQL/MariaDB store, Caffeine store,
   WebFlux (`Mono` handlers), and `mode: filter` for byte-exact replay
-- **0.4** — Operability: a claim lease separate from the retention window, `IdempotencyKeys` for
+- **0.4** — ✅ Operability: a claim lease separate from the retention window, `IdempotencyKeys` for
   addressing a record from your own code, an actuator endpoint to inspect and evict one, and an
   `idempotency.outcome` tag on the request's trace span
-- **0.5** — A reactive store SPI (R2DBC, reactive Redis), so WebFlux no longer schedules blocking
-  store calls onto `boundedElastic`; GraalVM native image hints
-- **0.6** — Kotlin coroutine support, `@Idempotent` on `@KafkaListener`
+- **1.0** — ✅ A stable, supported API. See [API stability](#api-stability)
+- **1.1** — A reactive store SPI (R2DBC, reactive Redis), so WebFlux no longer schedules blocking
+  store calls onto `boundedElastic`; GraalVM native image hints. Both additive
+- **1.2** — Kotlin coroutine support, `@Idempotent` on `@KafkaListener`
 
 ## Contributing
 

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/api/IdempotencyContext.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/api/IdempotencyContext.java
@@ -1,0 +1,52 @@
+package io.github.benhendayoussef.idempotency.api;
+
+import java.util.Optional;
+
+/**
+ * What the library knows about the request it is currently deciding a key for.
+ *
+ * <p>Passed to {@link ScopeResolver#namespace(IdempotencyContext)} so a resolver never has to read
+ * ambient state to do its job. Before 1.0 it did: {@code namespace()} took no arguments and reached
+ * into {@code SecurityContextHolder}, a ThreadLocal. That worked on the servlet stack and nowhere
+ * else, which is the whole reason {@code idempotency.scope} is restricted to {@code global} on
+ * WebFlux - the ThreadLocal is empty there, and falling back to global silently would have shared
+ * keys across users. Handing the resolver its inputs makes the SPI stack-agnostic, and makes it
+ * testable without standing up a security context.
+ *
+ * <p><strong>This is an interface, not a record, deliberately.</strong> Records cannot gain
+ * components compatibly, so a record here could never carry anything new without a major version.
+ * New accessors can be added to this interface with default bodies as the library learns what
+ * resolvers need.
+ *
+ * <p>Implementations are supplied by the library. Do not implement this yourself - new methods may
+ * appear in any minor release, and only the library can populate them correctly.
+ */
+public interface IdempotencyContext {
+
+    /** The raw key the client sent, before hashing - never blank. */
+    String clientKey();
+
+    /** The request's HTTP method, uppercase, e.g. {@code POST}. */
+    String httpMethod();
+
+    /**
+     * The matched route pattern (e.g. {@code /orders/{id}}), falling back to the request URI when no
+     * pattern matched. Two callers hitting the same route share a keyspace; different routes do not.
+     */
+    String routePattern();
+
+    /**
+     * The caller's authentication, when the stack has one and it has been resolved for this request.
+     *
+     * <p>Deliberately {@code Object} rather than Spring Security's {@code Authentication}: this
+     * package is the supported API and must not drag Spring Security onto the compile classpath of
+     * anyone who never uses a scoped key. Resolvers that want it should pattern-match, exactly as
+     * the built-in {@code USER} and {@code TENANT} resolvers do.
+     *
+     * <p>Empty means the library could not resolve a principal for this request - an anonymous
+     * caller, no security on the classpath, or a stack that does not populate it yet. A resolver
+     * that requires one should throw {@link IllegalStateException}; see
+     * {@link ScopeResolver#namespace(IdempotencyContext)} for what the library does with that.
+     */
+    Optional<Object> authentication();
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/api/ScopeResolver.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/api/ScopeResolver.java
@@ -4,11 +4,30 @@ package io.github.benhendayoussef.idempotency.api;
  * Resolves the namespace component of a storage key for a given {@link IdempotencyScope}.
  * Register a bean implementing this to override one of the built-in resolvers
  * (global, principal, tenant) — {@code @ConditionalOnMissingBean} lets a user-supplied bean win.
+ *
+ * <p>The namespace keeps unrelated callers from colliding on the same client-supplied key: user A's
+ * {@code "abc-123"} and user B's {@code "abc-123"} are different storage keys, so one caller can
+ * never replay another's response.
  */
 public interface ScopeResolver {
 
+    /** Which scope this resolver answers for. One resolver per scope. */
     IdempotencyScope supports();
 
-    /** May throw if the namespace can't be resolved for the current request (e.g. no auth). */
-    String namespace();
+    /**
+     * Returns the namespace for this request, or throws {@link IllegalStateException} if it cannot
+     * be resolved — typically because the caller is not authenticated.
+     *
+     * <p>An {@link IllegalStateException} from here is a <em>per-request</em> condition, not a
+     * wiring error, and the library treats it as one: it is routed through
+     * {@code idempotency.on-missing-principal}, which decides whether the request falls back to the
+     * global namespace, executes unprotected, or is rejected with a 400. Throwing any other type
+     * lets the exception escape to the caller, so throw {@code IllegalStateException} to opt into
+     * that policy.
+     *
+     * <p><strong>Changed in 1.0</strong>: this took no arguments before, and implementations read
+     * {@code SecurityContextHolder} directly. Everything a resolver needs now arrives in
+     * {@code context} — see {@link IdempotencyContext} for why.
+     */
+    String namespace(IdempotencyContext context);
 }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/CurrentAuthentication.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/CurrentAuthentication.java
@@ -1,0 +1,27 @@
+package io.github.benhendayoussef.idempotency.internal;
+
+import java.util.Optional;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Reads the servlet stack's current authentication out of Spring Security's ThreadLocal.
+ *
+ * <p><strong>This class must only be loaded when a scoped key is actually being resolved.</strong>
+ * Spring Security is {@code compileOnly} for this module, so referencing it from a code path that a
+ * {@code scope=global} application reaches would throw {@code NoClassDefFoundError} in every
+ * application that never asked for per-caller keys. {@code IdempotencyAspect.resolveNamespace}
+ * returns before touching this for {@code GLOBAL}, which keeps the class unloaded there - the same
+ * laziness the built-in resolvers have always depended on.
+ *
+ * <p>Not part of the supported API; see the package documentation.
+ */
+final class CurrentAuthentication {
+
+    private CurrentAuthentication() {
+    }
+
+    /** Empty when nobody is authenticated, or when no security context exists for this thread. */
+    static Optional<Object> get() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/IdempotencyAspect.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/IdempotencyAspect.java
@@ -7,6 +7,7 @@ import io.github.benhendayoussef.idempotency.api.FingerprintMismatchException;
 import io.github.benhendayoussef.idempotency.api.Idempotent;
 import io.github.benhendayoussef.idempotency.api.IdempotencyConflictException;
 import io.github.benhendayoussef.idempotency.api.IdempotencyKeyRequiredException;
+import io.github.benhendayoussef.idempotency.api.IdempotencyContext;
 import io.github.benhendayoussef.idempotency.api.IdempotencyMetrics;
 import io.github.benhendayoussef.idempotency.api.IdempotencyPrincipalRequiredException;
 import io.github.benhendayoussef.idempotency.api.IdempotencyRecord;
@@ -122,7 +123,7 @@ public class IdempotencyAspect implements Ordered {
         Duration ttl = resolveTtl(idempotent);
         String namespace;
         try {
-            namespace = resolveNamespace(idempotent);
+            namespace = resolveNamespace(idempotent, clientKey, request);
         } catch (MissingPrincipalException e) {
             switch (props.getOnMissingPrincipal()) {
                 case SKIP -> {
@@ -448,7 +449,7 @@ public class IdempotencyAspect implements Ordered {
         return Duration.parse(trimmed); // ISO-8601, e.g. PT30M
     }
 
-    private String resolveNamespace(Idempotent ann) {
+    private String resolveNamespace(Idempotent ann, String clientKey, HttpServletRequest request) {
         IdempotencyScope scope = ann.scope() == IdempotencyScope.DEFAULT ? props.getScope() : ann.scope();
         if (scope == IdempotencyScope.GLOBAL) {
             return "";
@@ -458,8 +459,14 @@ public class IdempotencyAspect implements Ordered {
             throw new IllegalStateException(
                     "No ScopeResolver registered for scope " + scope + " - register a bean implementing ScopeResolver");
         }
+        // Built only here, inside the non-GLOBAL branch. RequestIdempotencyContext resolves the
+        // authentication lazily, so CurrentAuthentication - and with it Spring Security, which is
+        // compileOnly for this module - is never loaded by an application that only uses global keys.
+        IdempotencyContext context = new RequestIdempotencyContext(
+                clientKey, request.getMethod(), IdempotencyKeyComposer.routePattern(request),
+                CurrentAuthentication::get);
         try {
-            return resolver.namespace();
+            return resolver.namespace(context);
         } catch (IllegalStateException e) {
             // The resolver itself is registered (a wiring/config problem, handled above) but this
             // specific request has no resolvable principal - a per-request condition, not a

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/IdempotencyKeyComposer.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/IdempotencyKeyComposer.java
@@ -13,9 +13,19 @@ import org.springframework.web.servlet.HandlerMapping;
 public class IdempotencyKeyComposer {
 
     public String compose(String clientKey, String namespace, HttpServletRequest request) {
-        String route = Objects.toString(
+        return IdempotencyKeys.storageKey(clientKey, request.getMethod(), routePattern(request), namespace);
+    }
+
+    /**
+     * The matched route pattern, falling back to the URI when nothing matched.
+     *
+     * <p>Static and shared because the scope context reports the same value to resolvers that the
+     * key is built from. Two definitions of "which route is this" that drifted apart would namespace
+     * a key by one route and store it under another.
+     */
+    public static String routePattern(HttpServletRequest request) {
+        return Objects.toString(
                 request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE),
                 request.getRequestURI());
-        return IdempotencyKeys.storageKey(clientKey, request.getMethod(), route, namespace);
     }
 }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/RequestIdempotencyContext.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/RequestIdempotencyContext.java
@@ -1,0 +1,28 @@
+package io.github.benhendayoussef.idempotency.internal;
+
+import io.github.benhendayoussef.idempotency.api.IdempotencyContext;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * The library's {@link IdempotencyContext}, built once per request that needs a scoped key.
+ *
+ * <p>Authentication arrives as a {@link Supplier} rather than a resolved value so that nothing
+ * touches the security context unless a resolver actually asks for it. That matters for more than
+ * speed: on a stack where resolving the principal is expensive - or, on a reactive stack, where it
+ * is a {@code Mono} that has to be subscribed - eagerly resolving it for every request would make
+ * the cheap resolvers pay for the expensive ones.
+ *
+ * <p>Not part of the supported API; see the package documentation.
+ */
+public record RequestIdempotencyContext(
+        String clientKey,
+        String httpMethod,
+        String routePattern,
+        Supplier<Optional<Object>> authenticationSupplier) implements IdempotencyContext {
+
+    @Override
+    public Optional<Object> authentication() {
+        return authenticationSupplier.get();
+    }
+}

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/GlobalScopeResolver.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/GlobalScopeResolver.java
@@ -1,5 +1,6 @@
 package io.github.benhendayoussef.idempotency.internal.scope;
 
+import io.github.benhendayoussef.idempotency.api.IdempotencyContext;
 import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
 import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 
@@ -12,7 +13,7 @@ public class GlobalScopeResolver implements ScopeResolver {
     }
 
     @Override
-    public String namespace() {
+    public String namespace(IdempotencyContext context) {
         return "";
     }
 }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/PrincipalScopeResolver.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/PrincipalScopeResolver.java
@@ -1,13 +1,18 @@
 package io.github.benhendayoussef.idempotency.internal.scope;
 
+import io.github.benhendayoussef.idempotency.api.IdempotencyContext;
 import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
 import io.github.benhendayoussef.idempotency.api.ScopeResolver;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Namespaces by the authenticated principal's name, so user A's key {@code "abc-123"} can never
  * collide with user B's. Only usable when Spring Security is on the classpath.
+ *
+ * <p>Takes the authentication from the context rather than {@code SecurityContextHolder}. Same
+ * result on the servlet stack, where the library populates it from exactly that ThreadLocal - but
+ * the dependency now points one way, so a stack that carries its principal somewhere else can
+ * supply it without this class changing.
  */
 public class PrincipalScopeResolver implements ScopeResolver {
 
@@ -17,11 +22,11 @@ public class PrincipalScopeResolver implements ScopeResolver {
     }
 
     @Override
-    public String namespace() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated()) {
+    public String namespace(IdempotencyContext context) {
+        Object auth = context.authentication().orElse(null);
+        if (!(auth instanceof Authentication authentication) || !authentication.isAuthenticated()) {
             throw new IllegalStateException("No authenticated principal for USER-scoped idempotency key");
         }
-        return auth.getName();
+        return authentication.getName();
     }
 }

--- a/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/TenantScopeResolver.java
+++ b/idempotency-core/src/main/java/io/github/benhendayoussef/idempotency/internal/scope/TenantScopeResolver.java
@@ -1,8 +1,9 @@
 package io.github.benhendayoussef.idempotency.internal.scope;
 
+import io.github.benhendayoussef.idempotency.api.IdempotencyContext;
 import io.github.benhendayoussef.idempotency.api.IdempotencyScope;
 import io.github.benhendayoussef.idempotency.api.ScopeResolver;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
@@ -24,10 +25,9 @@ public class TenantScopeResolver implements ScopeResolver {
     }
 
     @Override
-    public String namespace() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication() == null
-                ? null
-                : SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public String namespace(IdempotencyContext context) {
+        Object auth = context.authentication().orElse(null);
+        Object principal = auth instanceof Authentication authentication ? authentication.getPrincipal() : null;
         if (!(principal instanceof Jwt jwt)) {
             throw new IllegalStateException("No JWT principal for TENANT-scoped idempotency key");
         }

--- a/idempotency-spring-boot-starter/build.gradle.kts
+++ b/idempotency-spring-boot-starter/build.gradle.kts
@@ -80,6 +80,10 @@ tasks.test {
     // real embedded server + a JDK 21+ runtime to be meaningful at all, so it runs only via the
     // dedicated testVirtualThreads task below, on its own separate launcher.
     exclude("**/VirtualThreadsTest.class")
+    // Runs under testNoSpringSecurity instead. Here the Spring Security jars are present, so its
+    // assertions would hold whether or not the library touched them - and its guard test, which
+    // asserts the classes are absent, would fail.
+    exclude("**/NoSpringSecurityRequestTest.class")
 }
 
 // Virtual-threads check: runs the same test sources but on a JDK 21+ launcher, without changing
@@ -96,4 +100,23 @@ tasks.register<Test>("testVirtualThreads") {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
+}
+
+// The compileOnly boundary check. idempotency-core compiles against Spring Security but must never
+// link to it in an application that only uses idempotency.scope=global - and that failure mode is a
+// NoClassDefFoundError on the first request, not at startup, so a context test cannot catch it.
+//
+// It needs a genuinely smaller classpath rather than a FilteredClassLoader. FilteredClassLoader gates
+// the name lookups behind @ConditionalOnClass but does not stop runtime linkage in classes the
+// application class loader already defined, so a test using it passed even with the aspect calling
+// into Spring Security on every single request. Removing the jars is the only thing that tests this.
+tasks.register<Test>("testNoSpringSecurity") {
+    group = "verification"
+    description = "Runs NoSpringSecurityRequestTest with the Spring Security jars off the classpath."
+    testClassesDirs = tasks.test.get().testClassesDirs
+    classpath = tasks.test.get().classpath.filter { jar ->
+        !jar.name.startsWith("spring-security-") && !jar.name.startsWith("spring-boot-starter-security-")
+    }
+    useJUnitPlatform()
+    include("**/NoSpringSecurityRequestTest.class")
 }

--- a/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/NoSpringSecurityRequestTest.java
+++ b/idempotency-spring-boot-starter/src/test/java/io/github/benhendayoussef/idempotency/behavior/NoSpringSecurityRequestTest.java
@@ -1,0 +1,143 @@
+package io.github.benhendayoussef.idempotency.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.benhendayoussef.idempotency.api.Idempotent;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A whole request, in an application with <strong>no Spring Security on the classpath at all</strong>.
+ *
+ * <p>Spring Security is {@code compileOnly} for {@code idempotency-core}, so every reference to it
+ * has to sit on a path a {@code scope=global} application never reaches. Get that wrong and the
+ * failure is a {@code NoClassDefFoundError} on the first request rather than at startup - which
+ * passes every context test in this suite and breaks in production.
+ *
+ * <p>This runs only under the {@code testNoSpringSecurity} Gradle task, which strips the Spring
+ * Security jars from the test runtime classpath. It is excluded from the normal {@code test} task
+ * because there it would prove nothing: the classes would be present and the assertions would pass
+ * whether or not the library touched them.
+ *
+ * <p>An earlier attempt at this used {@code FilteredClassLoader} inside the ordinary suite and was
+ * <em>worthless</em>: it passed, and it went on passing after the aspect was deliberately changed to
+ * call into Spring Security on every request. {@code FilteredClassLoader} gates the name lookups
+ * that drive {@code @ConditionalOnClass}; it does not stop runtime linkage in classes the
+ * application class loader has already defined. Only a genuinely smaller classpath tests this, which
+ * is why this needs its own task and its own JVM. Hence {@link #springSecurityIsGenuinelyAbsent()} -
+ * if the classpath filter is ever removed or renamed, that test fails loudly instead of letting this
+ * whole class go quietly vacuous again.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = {NoSpringSecurityRequestTest.App.class, NoSpringSecurityRequestTest.Orders.class},
+        properties = {
+                "idempotency.store=memory",
+                TestAutoconfigExcludes.EXCLUDE_DATASOURCE_AND_SECURITY
+        })
+@Import(MockMvcTestConfiguration.class)
+class NoSpringSecurityRequestTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Orders orders;
+
+    // The context - and so the controller singleton - is shared by every test in this class.
+    // Without this the execution count carries over between them, which is how the first version
+    // of this test managed to report a working replay as a failure.
+    @BeforeEach
+    void resetCounter() {
+        orders.reset();
+    }
+
+    /**
+     * Guards every other assertion in this class. Without it, a change to the Gradle task's
+     * classpath filter would turn this suite into a second copy of the ordinary in-memory tests
+     * that still reports green.
+     */
+    @Test
+    void springSecurityIsGenuinelyAbsent() {
+        assertThatThrownBy(() -> Class.forName("org.springframework.security.core.context.SecurityContextHolder"))
+                .as("the testNoSpringSecurity task must strip Spring Security, or this class proves nothing")
+                .isInstanceOf(ClassNotFoundException.class);
+    }
+
+    @Test
+    void aGlobalScopedRequestExecutesOnceAndThenReplays() throws Exception {
+        String key = "no-security-" + System.nanoTime();
+
+        mockMvc.perform(post("/ns/orders").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"amount\":10}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/ns/orders").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"amount\":10}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Idempotent-Replay", "true"));
+
+        assertThat(orders.count())
+                .as("the handler must run exactly once - this has to actually work here, "
+                        + "not merely avoid throwing NoClassDefFoundError")
+                .isEqualTo(1);
+    }
+
+    /**
+     * The conflict path resolves a namespace too, and takes a different route through the aspect
+     * than the happy path does. Worth covering separately: a Security reference added to error
+     * handling would be missed by the test above.
+     */
+    @Test
+    void aFingerprintMismatchIsStillRejectedWithoutSecurityPresent() throws Exception {
+        String key = "no-security-mismatch-" + System.nanoTime();
+
+        mockMvc.perform(post("/ns/orders").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"amount\":10}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/ns/orders").header("Idempotency-Key", key)
+                        .contentType("application/json").content("{\"amount\":999}"))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @SpringBootApplication
+    static class App {
+    }
+
+    @RestController
+    static class Orders {
+
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Idempotent
+        @PostMapping("/ns/orders")
+        ResponseEntity<Map<String, Object>> place(@RequestBody Map<String, Object> body) {
+            calls.incrementAndGet();
+            return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("ok", true));
+        }
+
+        int count() {
+            return calls.get();
+        }
+
+        void reset() {
+            calls.set(0);
+        }
+    }
+}


### PR DESCRIPTION
## 1.0.0 — a stable, supported API

No new features. 1.0 is a commitment rather than a feature release: from here, everything listed
under **API stability** in the README is covered by semantic versioning, and breaking any of it
requires a 2.0.

### What's covered

`io.github.benhendayoussef.idempotency.api.**`, every `idempotency.*` property name and meaning,
the actuator endpoint, and the metric and trace names — plus two entries that aren't Java types and
matter more than they look:

- **The storage key format.** Changing it would orphan every record already in a user's store.
- **The stored record format.** A record written by 1.x stays readable by every later 1.x, so a
  rolling upgrade never strands in-flight keys.

Explicitly **not** covered: every `internal` package, in every module — each says so in its own
`package-info.java`, and a test enforces that they all do.

### Breaking change — `ScopeResolver`

`namespace()` took no arguments and implementations read `SecurityContextHolder` directly. That one
decision is *why* `idempotency.scope` has always been restricted to `global` on WebFlux: the
ThreadLocal is empty on a reactive stack, and silently falling back to global would have shared
idempotency keys across users, so failing startup was the only safe option left.

It now takes an `IdempotencyContext` carrying the client key, HTTP method, route pattern and
authentication. Reactive scoping becomes an **additive** change in 1.1 rather than a second parallel
SPI that has to exist forever alongside this one.

Done now because 1.0 is the last moment to change a signature in the `api` package without a major
version.

**Migration** — only affects `scope=custom`, or a bean overriding a built-in resolver:

```java
// before
public String namespace() {
    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
    return auth.getName();
}

// after
public String namespace(IdempotencyContext context) {
    Object auth = context.authentication().orElse(null);
    if (!(auth instanceof Authentication authentication)) {
        throw new IllegalStateException("no principal");   // routed through on-missing-principal
    }
    return authentication.getName();
}
```

Two design details worth knowing:

- `IdempotencyContext` is an **interface, not a record**, specifically so it can gain accessors in a
  minor release — the lesson `IdempotencyRecord` teaches by being a record that can never gain a
  component.
- Authentication arrives as a `Supplier`, so the class touching Spring Security is never loaded by an
  application using only global keys. Spring Security is `compileOnly` for `idempotency-core`.

`IdempotencyRecord` is frozen as-is, with its `RAW_PAYLOAD_TYPE` sentinel documented rather than
reworked — changing the shape would have changed the stored format and created a rolling-upgrade
hazard for existing users.

### Also added

- **`SECURITY.md`** — private vulnerability reporting via the Security tab, plus what actually counts
  as a vulnerability here. Cross-caller replay and key collision are the real threat classes; a
  replay to the same caller with the same key is the product working.
- **`github-release.yml`** — creates the GitHub Release from the tag, with notes extracted from the
  matching `CHANGELOG.md` section, using the runner's own `GITHUB_TOKEN`. Kept separate from
  `release.yml`, which publishes to Central and must run exactly once per version.

### A test that closes a real gap

`idempotency-core` compiles against Spring Security but must never link to it for a `scope=global`
application. That failure is a `NoClassDefFoundError` on the **first request**, not at startup — so
it passes every context test in the suite and breaks in production. Nothing covered it.

The obvious approach doesn't work. A `FilteredClassLoader` inside the ordinary suite gates the name
lookups behind `@ConditionalOnClass` but does not stop runtime linkage in classes the application
class loader has already defined: a test written that way passed, and went on passing after the
aspect was deliberately changed to call into Spring Security on every single request.

`testNoSpringSecurity` runs on a classpath with the jars genuinely removed. Verified by
reintroducing that same deliberate call — both request tests fail with `NoClassDefFoundError`, the
real production symptom. The class carries a guard test asserting Spring Security is absent, so if
the classpath filter is ever removed or renamed the suite fails loudly instead of going quietly
vacuous. Runs in CI on both Boot generations.

### Verification

| | Spring Boot 4.1.0 | Spring Boot 3.5.6 |
|---|---|---|
| Full suite | 278 tests, 0 failures | 278 tests, 0 failures |
| `testNoSpringSecurity` | 3 tests, 0 failures | 3 tests, 0 failures |

Against real Postgres, MySQL and Redis via Testcontainers.
`publishToMavenLocal -Pversion=1.0.0` produces jar + sources + javadoc + POM for all six modules.
